### PR TITLE
chore: Make relevant internal classes public for JSS.Lib

### DIFF
--- a/JSS.Lib/AST/Values/Boolean.cs
+++ b/JSS.Lib/AST/Values/Boolean.cs
@@ -1,8 +1,8 @@
 ﻿namespace JSS.Lib.AST.Values;
 
-internal sealed class Boolean : Value
+public sealed class Boolean : Value
 {
-    public Boolean(bool value)
+    internal Boolean(bool value)
     {
         Value = value;
     }

--- a/JSS.Lib/AST/Values/Number.cs
+++ b/JSS.Lib/AST/Values/Number.cs
@@ -1,8 +1,8 @@
 ﻿namespace JSS.Lib.AST.Values;
 
-internal sealed class Number : Value
+public sealed class Number : Value
 {
-    public Number(double value)
+    internal Number(double value)
     {
         Value = value;
     }
@@ -25,7 +25,7 @@ internal sealed class Number : Value
     }
 
     // 6.1.6.1.1 Number::unaryMinus ( x ), https://tc39.es/ecma262/#sec-numeric-types-number-unaryMinus
-    static public Number UnaryMinus(Number x)
+    static internal Number UnaryMinus(Number x)
     {
         // 1. If x is NaN, return NaN.
         if (double.IsNaN(x.Value)) return x;
@@ -35,7 +35,7 @@ internal sealed class Number : Value
     }
 
     // 6.1.6.1.2 Number::bitwiseNOT ( x ), https://tc39.es/ecma262/#sec-numeric-types-number-bitwiseNOT
-    static public Number BitwiseNOT(Number x)
+    static internal Number BitwiseNOT(Number x)
     {
         // FIXME: 1. Let oldValue be ! ToInt32(x).
 
@@ -46,7 +46,7 @@ internal sealed class Number : Value
     }
 
     // 6.1.6.1.3 Number::exponentiate ( base, exponent ), https://tc39.es/ecma262/#sec-numeric-types-number-exponentiate
-    static public Number Exponentiate(Number expBase, Number exponent)
+    static internal Number Exponentiate(Number expBase, Number exponent)
     {
         // FIXME: 1. If exponent is NaN, return NaN.
         // FIXME: 2. If exponent is either + 0𝔽 or - 0𝔽, return 1𝔽.
@@ -82,7 +82,7 @@ internal sealed class Number : Value
     }
 
     // 6.1.6.1.4 Number::multiply ( x, y ), https://tc39.es/ecma262/#sec-numeric-types-number-multiply
-    static public Number Multiply(Number x, Number y)
+    static internal Number Multiply(Number x, Number y)
     {
         // FIXME: 1. If x is NaN or y is NaN, return NaN.
         // FIXME: 2. If x is either +∞𝔽 or -∞𝔽, then
@@ -105,7 +105,7 @@ internal sealed class Number : Value
     }
 
     // 6.1.6.1.5 Number::divide ( x, y ), https://tc39.es/ecma262/#sec-numeric-types-number-divide
-    static public Number Divide(Number x, Number y)
+    static internal Number Divide(Number x, Number y)
     {
         // FIXME: 1. If x is NaN or y is NaN, return NaN.
         // FIXME: 2. If x is either +∞𝔽 or -∞𝔽, then
@@ -130,7 +130,7 @@ internal sealed class Number : Value
     }
 
     // 6.1.6.1.6 Number::remainder ( n, d ), https://tc39.es/ecma262/#sec-numeric-types-number-remainder
-    static public Number Remainder(Number n, Number d)
+    static internal Number Remainder(Number n, Number d)
     {
         // FIXME: 1. If n is NaN or d is NaN, return NaN.
         // FIXME: 2. If n is either +∞𝔽 or -∞𝔽, return NaN.
@@ -147,7 +147,7 @@ internal sealed class Number : Value
     }
 
     // 6.1.6.1.7 Number::add ( x, y ), https://tc39.es/ecma262/#sec-numeric-types-number-add
-    static public Number Add(Number x, Number y)
+    static internal Number Add(Number x, Number y)
     {
         // FIXME: 1. If x is NaN or y is NaN, return NaN.
         // FIXME: 2. If x is +∞𝔽 and y is -∞𝔽, return NaN.
@@ -162,13 +162,13 @@ internal sealed class Number : Value
     }
 
     // 6.1.6.1.8 Number::subtract ( x, y ), https://tc39.es/ecma262/#sec-numeric-types-number-subtract
-    static public Number Subtract(Number x, Number y)
+    static internal Number Subtract(Number x, Number y)
     {
         return Add(x, UnaryMinus(y));
     }
 
     // 6.1.6.1.9 Number::leftShift ( x, y ), https://tc39.es/ecma262/#sec-numeric-types-number-leftShift
-    static public Number LeftShift(Number x, Number y)
+    static internal Number LeftShift(Number x, Number y)
     {
         // FIXME: 1. Let lnum be !ToInt32(x).
         // FIXME: 2. Let rnum be !ToUint32(y).
@@ -180,7 +180,7 @@ internal sealed class Number : Value
     }
 
     // 6.1.6.1.10 Number::signedRightShift ( x, y ), https://tc39.es/ecma262/#sec-numeric-types-number-signedRightShift
-    static public Number SignedRightShift(Number x, Number y)
+    static internal Number SignedRightShift(Number x, Number y)
     {
         // FIXME: 1. Let lnum be !ToInt32(x).
         // FIXME: 2. Let rnum be !ToUint32(y).
@@ -192,7 +192,7 @@ internal sealed class Number : Value
     }
 
     // 6.1.6.1.11 Number::unsignedRightShift ( x, y ), https://tc39.es/ecma262/#sec-numeric-types-number-unsignedRightShift
-    static public Number UnsignedRightShift(Number x, Number y)
+    static internal Number UnsignedRightShift(Number x, Number y)
     {
         // FIXME: 1. Let lnum be !ToUint32(x).
         // FIXME: 2. Let rnum be !ToUint32(y).
@@ -204,7 +204,7 @@ internal sealed class Number : Value
     }
 
     // 6.1.6.1.12 Number::lessThan(x, y), https://tc39.es/ecma262/#sec-numeric-types-number-lessThan
-    static public Value LessThan(Number x, Number y)
+    static internal Value LessThan(Number x, Number y)
     {
         // FIXME: 1. If x is NaN, return undefined.
         // FIXME: 2. If y is NaN, return undefined.
@@ -222,7 +222,7 @@ internal sealed class Number : Value
     }
 
     // 6.1.6.1.13 Number::equal ( x, y )
-    static public Boolean Equal(Number x, Number y)
+    static internal Boolean Equal(Number x, Number y)
     {
         // 1. If x is NaN, return false.
         if (double.IsNaN(x.Value))
@@ -257,7 +257,7 @@ internal sealed class Number : Value
     }
 
     // 6.1.6.1.16 NumberBitwiseOp ( op, x, y ), https://tc39.es/ecma262/#sec-numberbitwiseop
-    static public Number NumberBitwiseOp(BitwiseOp op, Number x, Number y)
+    static internal Number NumberBitwiseOp(BitwiseOp op, Number x, Number y)
     {
         // FIXME: 1. Let lnum be !ToInt32(x).
         // FIXME: 2. Let rnum be !ToInt32(y).
@@ -284,27 +284,27 @@ internal sealed class Number : Value
     }
 
     // 6.1.6.1.17 Number::bitwiseAND ( x, y ), https://tc39.es/ecma262/#sec-numeric-types-number-bitwiseAND
-    static public Number BitwiseAND(Number x, Number y)
+    static internal Number BitwiseAND(Number x, Number y)
     {
         // 1. Return NumberBitwiseOp(&, x, y).
         return NumberBitwiseOp(BitwiseOp.AND, x, y);
     }
 
     // 6.1.6.1.18 Number::bitwiseXOR ( x, y ), https://tc39.es/ecma262/#sec-numeric-types-number-bitwiseXOR
-    static public Number BitwiseXOR(Number x, Number y)
+    static internal Number BitwiseXOR(Number x, Number y)
     {
         // 1. Return NumberBitwiseOp(^, x, y).
         return NumberBitwiseOp(BitwiseOp.XOR, x, y);
     }
 
     // 6.1.6.1.19 Number::bitwiseOR ( x, y ), https://tc39.es/ecma262/#sec-numeric-types-number-bitwiseOR
-    static public Number BitwiseOR(Number x, Number y)
+    static internal Number BitwiseOR(Number x, Number y)
     {
         // 1. Return NumberBitwiseOp(|, x, y).
         return NumberBitwiseOp(BitwiseOp.OR, x, y);
     }
 
-    static public Number NaN
+    static internal Number NaN
     {
         get
         {

--- a/JSS.Lib/AST/Values/Object.cs
+++ b/JSS.Lib/AST/Values/Object.cs
@@ -19,9 +19,9 @@ internal sealed class Property
 }
 
 // 6.1.7 The Object Type, https://tc39.es/ecma262/#sec-object-type
-internal class Object : Value
+public class Object : Value
 {
-    public Object(Object? prototype)
+    internal Object(Object? prototype)
     {
         Prototype = prototype ?? this;
         DataProperties = new();
@@ -31,14 +31,14 @@ internal class Object : Value
     override public ValueType Type() {  return ValueType.Object; }
 
     // 7.3.2 Get ( O, P ), https://tc39.es/ecma262/#sec-get-o-p
-    static public Completion Get(Object O, string P)
+    static internal Completion Get(Object O, string P)
     {
         // 1. Return ? O.[[Get]](P, O).
         return O.Get(P, O);
     }
 
     // 7.3.4 Set ( O, P, V, Throw ), https://tc39.es/ecma262/#sec-set-o-p-v-throw
-    static public Completion Set(Object O, string P, Value V, bool Throw)
+    static internal Completion Set(Object O, string P, Value V, bool Throw)
     {
         // 1. Let success be ? O.[[Set]](P, V, O).
         var success = O.Set(P, V, O);
@@ -57,7 +57,7 @@ internal class Object : Value
     }
 
     // 7.3.9 DefinePropertyOrThrow ( O, P, desc ), https://tc39.es/ecma262/#sec-definepropertyorthrow
-    static public Completion DefinePropertyOrThrow(Object O, string P, Property desc)
+    static internal Completion DefinePropertyOrThrow(Object O, string P, Property desc)
     {
         // 1. Let success be ? O.[[DefineOwnProperty]](P, desc).
         var success = O.DefineOwnProperty(P, desc);
@@ -72,14 +72,14 @@ internal class Object : Value
     }
 
     // 7.3.12 HasProperty ( O, P ), https://tc39.es/ecma262/#sec-hasproperty
-    static public Completion HasProperty(Object O, string P)
+    static internal Completion HasProperty(Object O, string P)
     {
         // 1. Return ? O.[[HasProperty]](P).
         return O.HasProperty(P);
     }
 
     // 7.3.13 HasOwnProperty ( O, P ), https://tc39.es/ecma262/#sec-hasownproperty
-    static public Completion HasOwnProperty(Object O, string P)
+    static internal Completion HasOwnProperty(Object O, string P)
     {
         // 1. Let desc be ? O.[[GetOwnProperty]](P).
         var desc = O.GetOwnProperty(P);
@@ -91,7 +91,7 @@ internal class Object : Value
     }
 
     // 7.3.14 Call ( F, V [ , argumentsList ] )
-    static public Completion Call(VM vm, Value F, Value V, Value? argumentsList = null)
+    static internal Completion Call(VM vm, Value F, Value V, Value? argumentsList = null)
     {
         // 1. If argumentsList is not present, set argumentsList to a new empty List.
         argumentsList ??= new List();
@@ -108,7 +108,7 @@ internal class Object : Value
     }
 
     // 10.1.5 [[GetOwnProperty]] ( P )
-    public Completion GetOwnProperty(string P)
+    internal Completion GetOwnProperty(string P)
     {
         // 1. Return OrdinaryGetOwnProperty(O, P).
         return OrdinaryGetOwnProperty(this, P);
@@ -139,14 +139,14 @@ internal class Object : Value
     }
 
     // 10.1.6 [[DefineOwnProperty]] ( P, Desc ), https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc
-    public Completion DefineOwnProperty(string P, Property desc)
+    internal Completion DefineOwnProperty(string P, Property desc)
     {
         // 1. Return ? OrdinaryDefineOwnProperty(O, P, Desc).
         return OrdinaryDefineOwnProperty(this, P, desc);
     }
 
     // 10.1.6.1 OrdinaryDefineOwnProperty ( O, P, Desc ), https://tc39.es/ecma262/#sec-ordinarydefineownproperty
-    static public Completion OrdinaryDefineOwnProperty(Object O, string P, Property desc)
+    static internal Completion OrdinaryDefineOwnProperty(Object O, string P, Property desc)
     {
         // FIXME: 1. Let current be ? O.[[GetOwnProperty]](P).
         // FIXME: 2. Let extensible be ? IsExtensible(O).
@@ -163,7 +163,7 @@ internal class Object : Value
     }
 
     // 10.1.7.1 OrdinaryHasProperty ( O, P ), https://tc39.es/ecma262/#sec-ordinaryhasproperty
-    static public Completion OrdinaryHasProperty(Object O, string P)
+    static internal Completion OrdinaryHasProperty(Object O, string P)
     {
         // 1. Let hasOwn be ? O.[[GetOwnProperty]](P).
         var hasOwn = O.GetOwnProperty(P);
@@ -179,14 +179,14 @@ internal class Object : Value
     }
 
     // 10.1.8 [[Get]] ( P, Receiver ), https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver
-    public Completion Get(string P, Object receiver)
+    internal Completion Get(string P, Object receiver)
     {
         // 1. Return ? OrdinaryGet(O, P, Receiver).
         return OrdinaryGet(this, P, receiver);
     }
 
     // 10.1.8.1 OrdinaryGet ( O, P, Receiver ), https://tc39.es/ecma262/#sec-ordinaryget
-    static public Completion OrdinaryGet(Object O, string P, Object receiver)
+    static internal Completion OrdinaryGet(Object O, string P, Object receiver)
     {
         // FIXME: 1. Let desc be ? O.[[GetOwnProperty]](P).
         // FIXME: 2. If desc is undefined, then
@@ -204,14 +204,14 @@ internal class Object : Value
     }
 
     // 10.1.9 [[Set]] ( P, V, Receiver ), https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver
-    public Completion Set(string P, Value V, Object receiver)
+    internal Completion Set(string P, Value V, Object receiver)
     {
         // 1. Return ? OrdinarySet(O, P, V, Receiver).
         return OrdinarySet(this, P, V, receiver);
     }
 
     // 10.1.9.1 OrdinarySet ( O, P, V, Receiver ), https://tc39.es/ecma262/#sec-ordinaryset
-    static public Completion OrdinarySet(Object O, string P, Value V, Object receiver)
+    static internal Completion OrdinarySet(Object O, string P, Value V, Object receiver)
     {
         // FIXME: 1. Let ownDesc be ? O.[[GetOwnProperty]](P).
         // FIXME: 2. Return ? OrdinarySetWithOwnDescriptor(O, P, V, Receiver, ownDesc).
@@ -229,6 +229,6 @@ internal class Object : Value
     }
 
     // FIXME: Accessor Attributes
-    public Object Prototype { get; }
-    public Dictionary<string, Property> DataProperties { get; }
+    internal Object Prototype { get; }
+    internal Dictionary<string, Property> DataProperties { get; }
 }

--- a/JSS.Lib/AST/Values/Reference.cs
+++ b/JSS.Lib/AST/Values/Reference.cs
@@ -4,9 +4,9 @@ using System.Diagnostics;
 namespace JSS.Lib.AST.Values;
 
 // 6.2.5 The Reference Record Specification Type, https://tc39.es/ecma262/#sec-reference-record-specification-type
-internal class Reference : Value
+public class Reference : Value
 {
-    public Reference(Value? @base, string referencedName, Value thisValue)
+    internal Reference(Value? @base, string referencedName, Value thisValue)
     {
         Base = @base;
         ReferencedName = referencedName;

--- a/JSS.Lib/AST/Values/String.cs
+++ b/JSS.Lib/AST/Values/String.cs
@@ -1,8 +1,8 @@
 ﻿namespace JSS.Lib.AST.Values;
 
-internal sealed class String : Value
+public sealed class String : Value
 {
-    public String(string value)
+    internal String(string value)
     {
         Value = value;
     }

--- a/JSS.Lib/AST/Values/Value.cs
+++ b/JSS.Lib/AST/Values/Value.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 
 namespace JSS.Lib.AST.Values;
 
-internal enum ValueType
+public enum ValueType
 {
     Undefined,
     Null,
@@ -18,7 +18,7 @@ internal enum ValueType
 
 // FIXME: This is a very inefficient way of storing JS values.
 // 6.1 ECMAScript Language Types, https://tc39.es/ecma262/#sec-ecmascript-language-types
-internal abstract class Value
+public abstract class Value
 {
     public static implicit operator Value(bool value) => new Boolean(value);
     public static implicit operator Value(double value) => new Number(value);
@@ -43,7 +43,7 @@ internal abstract class Value
         return (this as Reference)!;
     }
 
-    public Environment AsEnvironment()
+    internal Environment AsEnvironment()
     {
         Debug.Assert(IsEnvironment());
         return (this as Environment)!;
@@ -73,13 +73,13 @@ internal abstract class Value
         return (this as Object)!;
     }
 
-    public ICallable AsCallable()
+    internal ICallable AsCallable()
     {
         Debug.Assert(HasInternalCall());
         return (this as ICallable)!;
     }
 
-    public IConstructable AsConstructable()
+    internal IConstructable AsConstructable()
     {
         Debug.Assert(HasInternalConstruct());
         return (this as IConstructable)!;
@@ -91,7 +91,7 @@ internal abstract class Value
     abstract public ValueType Type();
 
     // 6.2.5.5 GetValue ( V ), https://tc39.es/ecma262/#sec-getvalue
-    public Completion GetValue()
+    internal Completion GetValue()
     {
         // 1. If V is not a Reference Record, return V.
         if (!IsReference())
@@ -137,7 +137,7 @@ internal abstract class Value
     }
 
     // 6.2.5.6 PutValue( V, W ), https://tc39.es/ecma262/#sec-putvalue
-    public Completion PutValue(VM vm, Value W)
+    internal Completion PutValue(VM vm, Value W)
     {
         // 1. If V is not a Reference Record, throw a ReferenceError exception.
         if (!IsReference())
@@ -197,7 +197,7 @@ internal abstract class Value
     }
 
     // 7.1.1 ToPrimitive ( input FIXME: [ , preferredType ] ), https://tc39.es/ecma262/#sec-toprimitive
-    public Completion ToPrimitive()
+    internal Completion ToPrimitive()
     {
         // FIXME: 1 .If input is an Object, then
         // FIXME: a. Let exoticToPrim be ? GetMethod(input, @@toPrimitive).
@@ -220,7 +220,7 @@ internal abstract class Value
     }
 
     // 7.1.2 ToBoolean ( argument ), https://tc39.es/ecma262/#sec-toboolean
-    public Boolean ToBoolean()
+    internal Boolean ToBoolean()
     {
         // 1. If argument is a Boolean, return argument.
         if (IsBoolean())
@@ -259,7 +259,7 @@ internal abstract class Value
     }
 
     // 7.1.3 ToNumeric ( value ), https://tc39.es/ecma262/#sec-tonumeric
-    public Completion ToNumeric()
+    internal Completion ToNumeric()
     {
         // 1. Let primValue be ? ToPrimitive(value, FIXME: NUMBER).
         var primValue = ToPrimitive();
@@ -272,7 +272,7 @@ internal abstract class Value
     }
 
     // 7.1.4 ToNumber ( argument ), https://tc39.es/ecma262/#sec-tonumber
-    public Completion ToNumber()
+    internal Completion ToNumber()
     {
         // 1. If argument is a Number, return argument.
         if (IsNumber()) return this;
@@ -316,7 +316,7 @@ internal abstract class Value
     }
 
     // 7.1.17 ToString ( argument ), https://tc39.es/ecma262/#sec-tostring
-    public Completion ToStringJS()
+    internal Completion ToStringJS()
     {
         // 1. If argument is a String, return argument.
         if (IsString()) return this;
@@ -353,7 +353,7 @@ internal abstract class Value
     }
 
     // 7.1.18 ToObject ( argument ), https://tc39.es/ecma262/#sec-toobject
-    public Completion ToObject()
+    internal Completion ToObject()
     {
         // Undefined, FIXME: Throw a TypeError exception.
         if (IsUndefined())
@@ -374,7 +374,7 @@ internal abstract class Value
     }
 
     // 7.1.19 ToPropertyKey ( argument ), https://tc39.es/ecma262/#sec-topropertykey
-    public Completion ToPropertyKey()
+    internal Completion ToPropertyKey()
     {
         // 1. Let key be ? ToPrimitive(argument, string).
         var key = ToPrimitive();
@@ -392,7 +392,7 @@ internal abstract class Value
     }
 
     // 7.2.3 IsCallable ( argument ), https://tc39.es/ecma262/#sec-iscallable
-    public bool IsCallable()
+    internal bool IsCallable()
     {
         // 1. If argument is not an Object, return false.
         if (!IsObject()) return false;
@@ -405,7 +405,7 @@ internal abstract class Value
     }
 
     // 7.2.4 IsConstructor ( argument ), https://tc39.es/ecma262/#sec-isconstructor
-    public bool IsConstructor()
+    internal bool IsConstructor()
     {
         // 1. If argument is not an Object, return false.
         if (!IsObject()) return false;
@@ -418,7 +418,7 @@ internal abstract class Value
     }
 
     // 7.2.12 SameValueNonNumber( x, y ), https://tc39.es/ecma262/#sec-samevaluenonnumber
-    static public Boolean SameValueNonNumber(Value x, Value y)
+    static internal Boolean SameValueNonNumber(Value x, Value y)
     {
         // 1. Assert: Type(x) is Type(y).
         Debug.Assert(x.Type().Equals(y.Type()));
@@ -456,7 +456,7 @@ internal abstract class Value
     }
 
     // 7.2.13 IsLessThan ( x, y, LeftFirst )
-    static public Completion IsLessThan(Value x, Value y, bool leftFirst)
+    static internal Completion IsLessThan(Value x, Value y, bool leftFirst)
     {
         Completion px;
         Completion py;
@@ -561,7 +561,7 @@ internal abstract class Value
     }
 
     // 7.2.14 IsLooselyEqual ( x, y ), https://tc39.es/ecma262/#sec-islooselyequal
-    static public Completion IsLooselyEqual(Value x, Value y)
+    static internal Completion IsLooselyEqual(Value x, Value y)
     {
         // 1. If Type(x) is Type(y), then
         if (x.Type().Equals(y.Type()))
@@ -635,7 +635,7 @@ internal abstract class Value
     }
 
     // 7.2.15 IsStrictlyEqual ( x, y ), https://tc39.es/ecma262/#sec-isstrictlyequal
-    static public Boolean IsStrictlyEqual(Value x, Value y)
+    static internal Boolean IsStrictlyEqual(Value x, Value y)
     {
         // 1. If Type(x) is not Type(y), return false.
         if (!x.Type().Equals(y.Type()))

--- a/JSS.Lib/Execution/Completion.cs
+++ b/JSS.Lib/Execution/Completion.cs
@@ -13,9 +13,9 @@ internal enum CompletionType
 }
 
 // 6.2.4 The Completion Record Specification Type, https://tc39.es/ecma262/#sec-completion-record-specification-type
-internal sealed class Completion
+public sealed class Completion
 {
-    public Completion(CompletionType type, Value value, string target)
+    internal Completion(CompletionType type, Value value, string target)
     {
         Type = type;
         Value = value;
@@ -116,7 +116,7 @@ internal sealed class Completion
 
     public bool IsValueEmpty() {  return Value.IsEmpty(); }
 
-    public CompletionType Type { get; }
+    internal CompletionType Type { get; }
     public Value Value { get; private set; }
     public string Target { get; }
 }

--- a/JSS.Lib/Execution/Realm.cs
+++ b/JSS.Lib/Execution/Realm.cs
@@ -5,10 +5,10 @@ using JSS.Lib.Runtime;
 namespace JSS.Lib.Execution;
 
 // 9.3 Realms, https://tc39.es/ecma262/#realm-record
-internal sealed class Realm
+public sealed class Realm
 {
     // 9.3.1 CreateRealm ( ), https://tc39.es/ecma262/#sec-createrealm
-    public Realm()
+    internal Realm()
     {
         // 1. Let realmRec be a new Realm Record.
         // FIXME: 2. Perform CreateIntrinsics(realmRec).
@@ -28,7 +28,7 @@ internal sealed class Realm
     }
 
     // 9.3.3 SetRealmGlobalObject ( realmRec, globalObj, thisValue ), https://tc39.es/ecma262/#sec-setrealmglobalobject
-    public void SetRealmGlobalObject(Object globalObj, Object thisValue)
+    internal void SetRealmGlobalObject(Object globalObj, Object thisValue)
     {
         // 1. If globalObj is undefined, then
         if (globalObj.IsUndefined())
@@ -95,7 +95,7 @@ internal sealed class Realm
     }
 
     // 9.4.6 GetGlobalObject ( ), https://tc39.es/ecma262/#sec-getglobalobject
-    static public Object GetGlobalObject(VM vm)
+    static internal Object GetGlobalObject(VM vm)
     {
         // 1. Let currentRealm be the current Realm Record.
         var currentRealm = vm.Realm;
@@ -142,9 +142,9 @@ internal sealed class Realm
         return Empty.The;
     }
 
-    public Agent Agent { get; }
-    public Object GlobalObject { get; private set; }
-    public GlobalEnvironment? GlobalEnv { get; private set; }
+    internal Agent Agent { get; }
+    internal Object GlobalObject { get; private set; }
+    internal GlobalEnvironment? GlobalEnv { get; private set; }
     // FIXME: [[Intrinsics]]
     // FIXME: [[LoadedModules]]
 }

--- a/JSS.Lib/Execution/Script.cs
+++ b/JSS.Lib/Execution/Script.cs
@@ -5,9 +5,9 @@ using System.Diagnostics;
 namespace JSS.Lib.Execution;
 
 // 16.1.4 Script Records, https://tc39.es/ecma262/#sec-script-records 
-internal sealed class Script
+public sealed class Script
 {
-    public Script(VM vm, StatementList statementList)
+    internal Script(VM vm, StatementList statementList)
     {
         VM = vm;
         Realm = vm.Realm;
@@ -276,7 +276,7 @@ internal sealed class Script
 
     public VM VM { get; }
     public Realm Realm { get; }
-    public IReadOnlyList<INode> ScriptCode
+    internal IReadOnlyList<INode> ScriptCode
     {
         get { return _statementList.Statements; }
     }

--- a/JSS.Lib/Execution/VM.cs
+++ b/JSS.Lib/Execution/VM.cs
@@ -1,31 +1,31 @@
 ﻿namespace JSS.Lib.Execution;
 
 // NOTE: This isn't required in the spec but is a helper for executing code
-internal sealed class VM
+public sealed class VM
 {
-    public VM(Realm realm)
+    internal VM(Realm realm)
     {
         Realm = realm;
     }
 
-    public void PushExecutionContext(ExecutionContext context)
+    internal void PushExecutionContext(ExecutionContext context)
     {
         _executionContextStack.Push(context);
     }
 
-    public void PopExecutionContext()
+    internal void PopExecutionContext()
     {
         _executionContextStack.Pop();
     }
 
-    public bool HasExecutionContext()
+    internal bool HasExecutionContext()
     {
         return _executionContextStack.Count > 0;
     }
 
     public Realm Realm { get; }
 
-    public ExecutionContext CurrentExecutionContext
+    internal ExecutionContext CurrentExecutionContext
     {
         get
         {

--- a/JSS.Lib/JSS.Lib.csproj
+++ b/JSS.Lib/JSS.Lib.csproj
@@ -9,8 +9,5 @@
 		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
 			<_Parameter1>JSS.Lib.UnitTests</_Parameter1>
 		</AssemblyAttribute>
-		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-			<_Parameter1>JSS.CLI</_Parameter1>
-		</AssemblyAttribute>
 	</ItemGroup>
 </Project>

--- a/JSS.Lib/Parser.cs
+++ b/JSS.Lib/Parser.cs
@@ -4,7 +4,7 @@ using JSS.Lib.Execution;
 
 namespace JSS.Lib;
 
-internal sealed class Parser
+public sealed class Parser
 {
     private readonly TokenConsumer _consumer;
 

--- a/JSS.Lib/SyntaxErrorException.cs
+++ b/JSS.Lib/SyntaxErrorException.cs
@@ -1,7 +1,7 @@
 ﻿namespace JSS.Lib;
 
 // NOTE: This is a exception used in the parser to "simulate" a SyntaxError being thrown in JS
-internal sealed class SyntaxErrorException : Exception
+public sealed class SyntaxErrorException : Exception
 {
     public SyntaxErrorException()
     {

--- a/JSS/Program.cs
+++ b/JSS/Program.cs
@@ -2,7 +2,6 @@
 using JSS.CLI;
 using JSS.Lib.Execution;
 
-// FIXME: We currently use "InternalsVisibleTo" for JSS.Lib, we should fix that
 var completion = Realm.InitializeHostDefinedRealm(out VM globalVm);
 if (completion.IsAbruptCompletion())
 {


### PR DESCRIPTION
Instead of having everything be internal and having internals visible to JSS.CLI, we only publicly expose what is needed for CLI to work.