### PR TITLE
feat: Add a basic benchmark suite for expression parsing and execution

### DIFF
--- a/JSS.Benchmarks/ASTBenchmarks/ExpressionExecution.cs
+++ b/JSS.Benchmarks/ASTBenchmarks/ExpressionExecution.cs
@@ -1,0 +1,40 @@
+﻿using BenchmarkDotNet.Attributes;
+using JSS.Lib;
+using JSS.Lib.Execution;
+
+namespace JSS.Benchmarks.ParserBenchmarks;
+
+public class ExpressionExecution
+{
+    [GlobalSetup]
+    public void SetupVM()
+    {
+        var completion = Realm.InitializeHostDefinedRealm(out VM vm);
+        if (completion.IsAbruptCompletion())
+        {
+            throw new InvalidOperationException("Unable to initialize a host defined realm");
+        }
+
+        var parser = new Parser(Expression);
+        _script = parser.Parse(vm);
+    }
+
+    [Benchmark]
+    public Completion ParseExpression()
+    {
+        return _script.ScriptEvaluation();
+    }
+
+    [ParamsSource(nameof(Expressions))]
+    public string Expression;
+    public string[] Expressions { get; } =
+    [
+        "1 || 2",
+        "1 || 2 && 3",
+        "1 || 2 && 3 | 4 & 5 ** 6",
+        "((((1 + 2) * 3) / 4) !== 5)",
+        "((((1 + 2) * 3) / 4) !== 5) + ((((1 + 2) * 3) / 4) !== 5) + ((((1 + 2) * 3) / 4) !== 5) + ((((1 + 2) * 3) / 4) !== 5) + ((((1 + 2) * 3) / 4) !== 5)",
+    ];
+
+    private Script _script;
+}

--- a/JSS.Benchmarks/JSS.Benchmarks.csproj
+++ b/JSS.Benchmarks/JSS.Benchmarks.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\JSS.Lib\JSS.Lib.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/JSS.Benchmarks/ParserBenchmarks/ExpressionParsing.cs
+++ b/JSS.Benchmarks/ParserBenchmarks/ExpressionParsing.cs
@@ -1,0 +1,40 @@
+﻿using BenchmarkDotNet.Attributes;
+using JSS.Lib;
+using JSS.Lib.Execution;
+
+namespace JSS.Benchmarks.ParserBenchmarks;
+
+public class ExpressionParsing
+{
+    [GlobalSetup]
+    public void SetupVM()
+    {
+        var completion = Realm.InitializeHostDefinedRealm(out _vm);
+        if (completion.IsAbruptCompletion())
+        {
+            throw new InvalidOperationException("Unable to initialize a host defined realm");
+        }
+
+        _parser = new Parser(Expression);
+    }
+
+    [Benchmark]
+    public Script ParseExpression()
+    {
+        return _parser.Parse(_vm);
+    }
+
+    [ParamsSource(nameof(Expressions))]
+    public string Expression;
+    public string[] Expressions { get; } =
+    [
+        "1 || 2",
+        "1 || 2 && 3",
+        "1 || 2 && 3 | 4 & 5 ** 6",
+        "((((1 + 2) * 3) / 4) !== 5)",
+        "((((1 + 2) * 3) / 4) !== 5) + ((((1 + 2) * 3) / 4) !== 5) + ((((1 + 2) * 3) / 4) !== 5) + ((((1 + 2) * 3) / 4) !== 5) + ((((1 + 2) * 3) / 4) !== 5)",
+    ];
+
+    private VM _vm;
+    private Parser _parser;
+}

--- a/JSS.Benchmarks/Program.cs
+++ b/JSS.Benchmarks/Program.cs
@@ -1,0 +1,5 @@
+﻿using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher
+    .FromAssembly(typeof(Program).Assembly)
+    .Run(args);

--- a/JSS.Lib/JSS.Lib.csproj
+++ b/JSS.Lib/JSS.Lib.csproj
@@ -10,4 +10,10 @@
 			<_Parameter1>JSS.Lib.UnitTests</_Parameter1>
 		</AssemblyAttribute>
 	</ItemGroup>
+
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>JSS.Benchmarks</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
 </Project>

--- a/JSS.sln
+++ b/JSS.sln
@@ -12,6 +12,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JSS.Lib", "JSS.Lib\JSS.Lib.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JSS.Lib.UnitTests", "JSS.Lib.UnitTests\JSS.Lib.UnitTests.csproj", "{DC388CFD-CBBC-47B8-A23D-C46A9926E32B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JSS.Benchmarks", "JSS.Benchmarks\JSS.Benchmarks.csproj", "{7AFEECCF-18D0-4BBE-B81D-B92FAB677E73}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,6 +32,10 @@ Global
 		{DC388CFD-CBBC-47B8-A23D-C46A9926E32B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DC388CFD-CBBC-47B8-A23D-C46A9926E32B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DC388CFD-CBBC-47B8-A23D-C46A9926E32B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7AFEECCF-18D0-4BBE-B81D-B92FAB677E73}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7AFEECCF-18D0-4BBE-B81D-B92FAB677E73}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7AFEECCF-18D0-4BBE-B81D-B92FAB677E73}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7AFEECCF-18D0-4BBE-B81D-B92FAB677E73}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
We add a basic benchmark suite that parses and executes some basic expressions.

This is currently just a toy to see how fast JSS.Lib is and can be expanded further when we are able to do more.