### PR TITLE
Implement an "AbruptOr" paradigm for getting specific types from a potentially throwing type

### DIFF
--- a/JSS.Lib.UnitTests/AbstractOperationTests.cs
+++ b/JSS.Lib.UnitTests/AbstractOperationTests.cs
@@ -87,11 +87,8 @@ internal sealed class AbstractOperationTests
         var asNumber = testCase.ToNumber();
 
         // Assert
-        asNumber.IsNormalCompletion().Should().BeTrue();
-
-        var numberValue = asNumber.Value as Number;
-        numberValue.Should().NotBeNull();
-        numberValue!.Value.Should().Be(expectedNumber);
+        asNumber.IsAbruptCompletion().Should().BeFalse();
+        asNumber.Value.Should().Be(expectedNumber);
     }
 
     [TestCaseSource(nameof(valueToExpectedNumberTestCases))]

--- a/JSS.Lib.UnitTests/AbstractOperationTests.cs
+++ b/JSS.Lib.UnitTests/AbstractOperationTests.cs
@@ -58,11 +58,8 @@ internal sealed class AbstractOperationTests
         var asString = testCase.ToStringJS();
 
         // Assert
-        asString.IsNormalCompletion().Should().BeTrue();
-
-        var stringValue = asString.Value as String;
-        stringValue.Should().NotBeNull();
-        stringValue!.Value.Should().Be(expectedString);
+        asString.IsAbruptCompletion().Should().BeFalse();
+        asString.Value.Should().Be(expectedString);
     }
 
     static private readonly object[] valueToExpectedNumberTestCases = new object[]

--- a/JSS.Lib.UnitTests/ValueTests.cs
+++ b/JSS.Lib.UnitTests/ValueTests.cs
@@ -8,9 +8,9 @@ internal sealed class ValueTests
     // Tests for 7.1.6 ToInt32 ( argument ), https://tc39.es/ecma262/#sec-toint32
     static private readonly object[] toInt32TestCases =
     {
-        new object[] { 0.0, 0.0 },
-        new object[] { 1.0, 1.0 },
-        new object[] { -1.0, -1.0 },
+        new object[] { 0.0, 0 },
+        new object[] { 1.0, 1 },
+        new object[] { -1.0, -1 },
         new object[] { uint.MaxValue, -1 },
         new object[] { int.MaxValue, int.MaxValue },
         new object[] { (uint)int.MaxValue + 1, int.MinValue },
@@ -19,47 +19,43 @@ internal sealed class ValueTests
     };
 
     [TestCaseSource(nameof(toInt32TestCases))]
-    public void ToInt32_ReturnsNormalCompletion_WithExpectedResult(double input, double expected)
+    public void ToInt32_ReturnsNormalCompletion_WithExpectedResult(double input, int expected)
     {
         // Arrange
         Value inputValue = input;
 
         // Act
-        var completion = inputValue.ToInt32();
+        var abruptOr = inputValue.ToInt32();
 
         // Assert
-        completion.IsNormalCompletion().Should().BeTrue();
-
-        var actual = completion.Value.AsNumber();
-        actual.Value.Should().Be(expected);
+        abruptOr.IsAbruptCompletion().Should().BeFalse();
+        abruptOr.Value.Should().Be(expected);
     }
 
     // 7.1.7 ToUint32 ( argument ), https://tc39.es/ecma262/#sec-touint32
     static private readonly object[] toUint32TestCases =
     {
-        new object[] { 0.0, 0.0 },
-        new object[] { 1.0, 1.0 },
+        new object[] { 0.0, 0U },
+        new object[] { 1.0, 1U },
         new object[] { -1.0, uint.MaxValue },
         new object[] { uint.MaxValue, uint.MaxValue },
-        new object[] { int.MaxValue, int.MaxValue },
+        new object[] { int.MaxValue, (uint)int.MaxValue },
         new object[] { (uint)int.MaxValue + 1, (uint)int.MaxValue + 1 },
-        new object[] { double.MaxValue, 0 },
-        new object[] { double.MinValue, 0 },
+        new object[] { double.MaxValue, 0U },
+        new object[] { double.MinValue, 0U },
     };
 
     [TestCaseSource(nameof(toUint32TestCases))]
-    public void ToUint32_ReturnsNormalCompletion_WithExpectedResult(double input, double expected)
+    public void ToUint32_ReturnsNormalCompletion_WithExpectedResult(double input, uint expected)
     {
         // Arrange
         Value inputValue = input;
 
         // Act
-        var completion = inputValue.ToUint32();
+        var abruptOr = inputValue.ToUint32();
 
         // Assert
-        completion.IsNormalCompletion().Should().BeTrue();
-
-        var actual = completion.Value.AsNumber();
-        actual.Value.Should().Be(expected);
+        abruptOr.IsAbruptCompletion().Should().BeFalse();
+        abruptOr.Value.Should().Be(expected);
     }
 }

--- a/JSS.Lib/AST/IExpression.cs
+++ b/JSS.Lib/AST/IExpression.cs
@@ -47,9 +47,7 @@ internal abstract class IExpression : INode
                 if (rstr.IsAbruptCompletion()) return rstr;
 
                 // iii. Return the string-concatenation of lstr and rstr.
-                var lstrValue = lstr.Value.AsString();
-                var rstrValue = rstr.Value.AsString();
-                return lstrValue.Value + rstrValue.Value;
+                return lstr.Value + rstr.Value;
             }
 
             // d. Set lval to lprim.

--- a/JSS.Lib/AST/Values/Number.cs
+++ b/JSS.Lib/AST/Values/Number.cs
@@ -38,12 +38,11 @@ public sealed class Number : Value
     static internal Number BitwiseNOT(Number x)
     {
         // 1. Let oldValue be ! ToInt32(x).
-        var oldValue = MUST(x.ToInt32()).AsNumber(); ;
+        var oldValue = MUST(x.ToInt32());
 
         // 2. Return the result of applying bitwise complement to oldValue.
         // The mathematical value of the result is exactly representable as a 32-bit two's complement bit string.
-        var result = ~(int)oldValue.Value;
-        return result;
+        return ~oldValue;
     }
 
     // 6.1.6.1.3 Number::exponentiate ( base, exponent ), https://tc39.es/ecma262/#sec-numeric-types-number-exponentiate
@@ -172,51 +171,51 @@ public sealed class Number : Value
     static internal Number LeftShift(Number x, Number y)
     {
         // 1. Let lnum be !ToInt32(x).
-        var lnum = MUST(x.ToInt32()).AsNumber();
+        var lnum = MUST(x.ToInt32());
 
         // 2. Let rnum be !ToUint32(y).
-        var rnum = MUST(y.ToUint32()).AsNumber();
+        var rnum = MUST(y.ToUint32());
 
         // 3. Let shiftCount be ℝ(rnum) modulo 32.
-        var shiftCount = (uint)rnum.Value % 32;
+        var shiftCount = rnum % 32;
 
         // 4. Return the result of left shifting lnum by shiftCount bits.
         // The mathematical value of the result is exactly representable as a 32-bit two's complement bit string.
-        return (int)lnum.Value << (int)shiftCount;
+        return lnum << (int)shiftCount;
     }
 
     // 6.1.6.1.10 Number::signedRightShift ( x, y ), https://tc39.es/ecma262/#sec-numeric-types-number-signedRightShift
     static internal Number SignedRightShift(Number x, Number y)
     {
         // 1. Let lnum be !ToInt32(x).
-        var lnum = MUST(x.ToInt32()).AsNumber();
+        var lnum = MUST(x.ToInt32());
 
         // 2. Let rnum be !ToUint32(y).
-        var rnum = MUST(y.ToUint32()).AsNumber();
+        var rnum = MUST(y.ToUint32());
 
         // 3. Let shiftCount be ℝ(rnum) modulo 32.
-        var shiftCount = (uint)rnum.Value % 32;
+        var shiftCount = rnum % 32;
 
         // 4. Return the result of performing a sign-extending right shift of lnum by shiftCount bits.
         // The most significant bit is propagated.The mathematical value of the result is exactly representable as a 32-bit two's complement bit string.
-        return (int)lnum.Value >> (int)shiftCount;
+        return lnum >> (int)shiftCount;
     }
 
     // 6.1.6.1.11 Number::unsignedRightShift ( x, y ), https://tc39.es/ecma262/#sec-numeric-types-number-unsignedRightShift
     static internal Number UnsignedRightShift(Number x, Number y)
     {
         // 1. Let lnum be !ToUint32(x).
-        var lnum = MUST(x.ToUint32()).AsNumber();
+        var lnum = MUST(x.ToUint32());
 
         // 2. Let rnum be !ToUint32(y).
-        var rnum = MUST(y.ToUint32()).AsNumber();
+        var rnum = MUST(y.ToUint32());
 
         // 3. Let shiftCount be ℝ(rnum) modulo 32.
-        var shiftCount = (uint)rnum.Value % 32;
+        var shiftCount = rnum % 32;
 
         // 4. Return the result of performing a zero-filling right shift of lnum by shiftCount bits.
         // Vacated bits are filled with zero. The mathematical value of the result is exactly representable as a 32-bit unsigned bit string.
-        return (int)lnum.Value >>> (int)shiftCount;
+        return lnum >>> (int)shiftCount;
     }
 
     // 6.1.6.1.12 Number::lessThan(x, y), https://tc39.es/ecma262/#sec-numeric-types-number-lessThan
@@ -276,16 +275,13 @@ public sealed class Number : Value
     static internal Number NumberBitwiseOp(BitwiseOp op, Number x, Number y)
     {
         // 1. Let lnum be !ToInt32(x).
-        var lnum = MUST(x.ToInt32()).AsNumber();
+        var lnum = MUST(x.ToInt32());
 
         // 2. Let rnum be !ToInt32(y).
-        var rnum = MUST(y.ToInt32()).AsNumber();
+        var rnum = MUST(y.ToInt32());
 
         // 3. Let lbits be the 32-bit two's complement bit string representing ℝ(lnum).
-        var lbits = (int)lnum.Value;
-
         // 4. Let rbits be the 32-bit two's complement bit string representing ℝ(rnum).
-        var rbits = (int)rnum.Value;
 
         // 5. If op is &, then
         // a. Let result be the result of applying the bitwise AND operation to lbits and rbits.
@@ -296,9 +292,9 @@ public sealed class Number : Value
         // b. Let result be the result of applying the bitwise inclusive OR operation to lbits and rbits.
         var result = op switch
         {
-            BitwiseOp.AND => lbits & rbits,
-            BitwiseOp.XOR => lbits ^ rbits,
-            BitwiseOp.OR => lbits | rbits,
+            BitwiseOp.AND => lnum & rnum,
+            BitwiseOp.XOR => lnum ^ rnum,
+            BitwiseOp.OR => lnum | rnum,
             _ => throw new InvalidOperationException(),
         };
 

--- a/JSS.Lib/AST/Values/Value.cs
+++ b/JSS.Lib/AST/Values/Value.cs
@@ -118,7 +118,7 @@ public abstract class Value
             // FIXME: i. Return ? PrivateGet(baseObj, V.[[ReferencedName]]).
 
             // c. Return ? baseObj.[[Get]](V.[[ReferencedName]], FIXME: GetThisValue(V)).
-            var obj = baseObj.Value.AsObject();
+            var obj = baseObj.Value;
             return obj.Get(asReference.ReferencedName, obj);
         }
         // 4. Else,
@@ -168,12 +168,13 @@ public abstract class Value
         {
             // a. Let baseObj be ? ToObject(V.[[Base]]).
             var baseObj = reference.Base!.ToObject();
+            if (baseObj.IsAbruptCompletion()) return baseObj;
 
             // FIXME: b. If IsPrivateReference(V) is true, then
             // FIXME: i. Return ? PrivateSet(baseObj, V.[[ReferencedName]], W).
 
             // FIXME: c. Let succeeded be ? baseObj.[[Set]](V.[[ReferencedName]], W, FIXME: GetThisValue(V)).
-            var obj = baseObj.Value.AsObject();
+            var obj = baseObj.Value;
             var succeeded = obj.Set(reference.ReferencedName, W, obj);
             if (succeeded.IsAbruptCompletion()) return succeeded;
 
@@ -401,7 +402,7 @@ public abstract class Value
     }
 
     // 7.1.18 ToObject ( argument ), https://tc39.es/ecma262/#sec-toobject
-    internal Completion ToObject()
+    internal AbruptOr<Object> ToObject()
     {
         // Undefined, FIXME: Throw a TypeError exception.
         if (IsUndefined())
@@ -418,7 +419,7 @@ public abstract class Value
         // FIXME: Implement the rest of the conversions
 
         // Object, Return argument.
-        return this;
+        return AsObject();
     }
 
     // 7.1.19 ToPropertyKey ( argument ), https://tc39.es/ecma262/#sec-topropertykey

--- a/JSS.Lib/AST/Values/Value.cs
+++ b/JSS.Lib/AST/Values/Value.cs
@@ -364,10 +364,10 @@ public abstract class Value
     }
 
     // 7.1.17 ToString ( argument ), https://tc39.es/ecma262/#sec-tostring
-    internal Completion ToStringJS()
+    internal AbruptOr<string> ToStringJS()
     {
         // 1. If argument is a String, return argument.
-        if (IsString()) return this;
+        if (IsString()) return AsString().Value;
 
         // FIXME: 2. If argument is a Symbol, throw a TypeError exception.
 

--- a/JSS.Lib/AST/Values/Value.cs
+++ b/JSS.Lib/AST/Values/Value.cs
@@ -272,10 +272,10 @@ public abstract class Value
     }
 
     // 7.1.4 ToNumber ( argument ), https://tc39.es/ecma262/#sec-tonumber
-    internal Completion ToNumber()
+    internal AbruptOr<double> ToNumber()
     {
         // 1. If argument is a Number, return argument.
-        if (IsNumber()) return this;
+        if (IsNumber()) return AsNumber().Value;
 
         // FIXME: 2. If argument is either a Symbol or a BigInt, throw a TypeError exception.
 
@@ -304,7 +304,7 @@ public abstract class Value
             }
             catch (Exception)
             {
-                return Number.NaN;
+                return double.NaN;
             }
         }
 
@@ -316,21 +316,21 @@ public abstract class Value
     }
 
     // 7.1.6 ToInt32 ( argument ), https://tc39.es/ecma262/#sec-toint32
-    internal Completion ToInt32()
+    internal AbruptOr<int> ToInt32()
     {
         const long TWO_TO_32 = (long)uint.MaxValue + 1;
         const long TWO_TO_31 = (long)int.MaxValue + 1;
 
         // 1. Let number be ? ToNumber(argument).
         var number = ToNumber();
-        if (number.IsAbruptCompletion()) return number;
+        if (number.IsAbruptCompletion()) return number.Completion;
 
         // 2. If number is FIXME: not finite or number is either +0𝔽 FIXME: or -0𝔽, return +0𝔽.
-        var numberValue = number.Value.AsNumber();
-        if (numberValue.Value == 0.0) return 0;
+        var numberValue = number.Value;
+        if (numberValue == 0.0) return 0;
 
         // 3. Let int be truncate(ℝ(number)).
-        var @int = (long)numberValue.Value;
+        var @int = (long)numberValue;
 
         // 4. Let int32bit be int modulo 2**32.
         var int32bit = @int % TWO_TO_32;
@@ -341,20 +341,20 @@ public abstract class Value
     }
 
     // 7.1.7 ToUint32 ( argument ), https://tc39.es/ecma262/#sec-touint32
-    internal Completion ToUint32()
+    internal AbruptOr<uint> ToUint32()
     {
         const long TWO_TO_32 = (long)uint.MaxValue + 1;
 
         // 1. Let number be ? ToNumber(argument).
         var number = ToNumber();
-        if (number.IsAbruptCompletion()) return number;
+        if (number.IsAbruptCompletion()) return number.Completion;
 
         // 2. If number is FIXME: not finite or number is either +0𝔽 FIXME: or -0𝔽, return +0𝔽.
-        var numberValue = number.Value.AsNumber();
-        if (numberValue.Value == 0.0) return 0;
+        var numberValue = number.Value;
+        if (numberValue == 0.0) return 0;
 
         // 3. Let int be truncate(ℝ(number)).
-        var @int = (long)numberValue.Value;
+        var @int = (long)numberValue;
 
         // 4. Let int32bit be int modulo 2**32.
         var int32bit = @int % TWO_TO_32;
@@ -653,23 +653,15 @@ public abstract class Value
         // 9. If x is a Boolean, return !IsLooselyEqual(!ToNumber(x), y).
         if (x.IsBoolean())
         {
-            var xAsNumber = x.ToNumber();
-            Debug.Assert(xAsNumber.IsNormalCompletion());
-
-            var result = IsLooselyEqual(xAsNumber.Value, y);
-            Debug.Assert(result.IsNormalCompletion());
-            return result;
+            var xAsNumber = MUST(x.ToNumber());
+            return MUST(IsLooselyEqual(xAsNumber, y));
         }
 
         // 10. If y is a Boolean, return !IsLooselyEqual(x, !ToNumber(y)).
         if (y.IsBoolean())
         {
-            var yAsNumber = y.ToNumber();
-            Debug.Assert(yAsNumber.IsNormalCompletion());
-
-            var result = IsLooselyEqual(x, yAsNumber.Value);
-            Debug.Assert(result.IsNormalCompletion());
-            return result;
+            var yAsNumber = MUST(y.ToNumber());
+            return MUST(IsLooselyEqual(x, yAsNumber));
         }
 
         // FIXME: 11. If x is either a String, a Number, a BigInt, or a Symbol and y is an Object, return !IsLooselyEqual(x, ? ToPrimitive(y)).

--- a/JSS.Lib/AST/Values/Value.cs
+++ b/JSS.Lib/AST/Values/Value.cs
@@ -504,7 +504,7 @@ public abstract class Value
         throw new NotImplementedException();
     }
 
-    // 7.2.13 IsLessThan ( x, y, LeftFirst )
+    // 7.2.13 IsLessThan ( x, y, LeftFirst ), https://tc39.es/ecma262/#sec-islessthan
     static internal Completion IsLessThan(Value x, Value y, bool leftFirst)
     {
         Completion px;

--- a/JSS.Lib/Execution/AbruptOr.cs
+++ b/JSS.Lib/Execution/AbruptOr.cs
@@ -1,0 +1,65 @@
+﻿using OneOf;
+
+namespace JSS.Lib.Execution;
+
+/// <summary>
+/// Used to represent either an abrupt completion or <see cref="T"/>. <br/>
+/// This allows us to directly return any <see cref="T"/> instead of being wrapped in a value. <br/>
+/// </summary>
+/// <typeparam name="T">The type that the non-abrupt completion path should return</typeparam>
+public sealed class AbruptOr<T> where T : notnull
+{
+    private AbruptOr(T value)
+    {
+        _value = value;
+    }
+
+    private AbruptOr(Completion abruptCompletion)
+    {
+        _value = abruptCompletion;
+    }
+
+    /// <summary>
+    /// Used for implicitly creating an <see cref="AbruptOr{T}"/> from a non-abrupt completion value.
+    /// </summary>
+    public static implicit operator AbruptOr<T>(T value) => new(value);
+
+    /// <summary>
+    /// Used for implicitly creating an <see cref="AbruptOr{T}"/> from an abrupt completion.
+    /// </summary>
+    public static implicit operator AbruptOr<T>(Completion abruptCompletion) => new(abruptCompletion);
+
+    /// <returns>
+    /// <see cref="true"/> if <see cref="AbruptOr{T}"/> contains an abrupt completion, otherwise, <see cref="false"/>.
+    /// </returns>
+    public bool IsAbruptCompletion() { return _value.IsT1; }
+
+    /// <summary>
+    /// Returns the value that the non-abrupt completion path holds.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <see cref="AbruptOr{T}"/> is an abrupt completion.
+    /// </exception>
+    public T Value {
+        get
+        {
+            return _value.AsT0;
+        }
+    }
+
+    /// <summary>
+    /// Returns the value that the abrupt completion path holds.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <see cref="AbruptOr{T}"/> is not an abrupt completion.
+    /// </exception>
+    public Completion Completion
+    {
+        get
+        {
+            return _value.AsT1;
+        }
+    }
+
+    private readonly OneOf<T, Completion> _value;
+}

--- a/JSS.Lib/Execution/Completion.cs
+++ b/JSS.Lib/Execution/Completion.cs
@@ -58,6 +58,12 @@ public sealed class Completion
         return abruptOr.Value;
     }
 
+    public static implicit operator Completion(AbruptOr<Object> abruptOr)
+    {
+        if (abruptOr.IsAbruptCompletion()) return abruptOr.Completion;
+        return abruptOr.Value;
+    }
+
     // 6.2.4.2 ThrowCompletion ( value ), https://tc39.es/ecma262/#sec-throwcompletion
     static public Completion ThrowCompletion(Value value)
     {

--- a/JSS.Lib/Execution/Completion.cs
+++ b/JSS.Lib/Execution/Completion.cs
@@ -46,6 +46,12 @@ public sealed class Completion
     public static implicit operator Completion(double value) => NormalCompletion(value);
     public static implicit operator Completion(string value) => NormalCompletion(value);
 
+    public static implicit operator Completion(AbruptOr<double> abruptOr)
+    {
+        if (abruptOr.IsAbruptCompletion()) return abruptOr.Completion;
+        return abruptOr.Value;
+    }
+
     // 6.2.4.2 ThrowCompletion ( value ), https://tc39.es/ecma262/#sec-throwcompletion
     static public Completion ThrowCompletion(Value value)
     {
@@ -135,5 +141,16 @@ internal static class CompletionHelper
 
         // 3. Set val to val.[[Value]].
         return completion.Value;
+    }
+
+    static public T MUST<T>(AbruptOr<T> abruptOr) where T : notnull
+    {
+        // 1. Let val be OperationName().
+
+        // 2. Assert: val is a normal completion.
+        Debug.Assert(!abruptOr.IsAbruptCompletion());
+
+        // 3. Set val to val.[[Value]].
+        return abruptOr.Value;
     }
 }

--- a/JSS.Lib/Execution/Completion.cs
+++ b/JSS.Lib/Execution/Completion.cs
@@ -52,6 +52,12 @@ public sealed class Completion
         return abruptOr.Value;
     }
 
+    public static implicit operator Completion(AbruptOr<string> abruptOr)
+    {
+        if (abruptOr.IsAbruptCompletion()) return abruptOr.Completion;
+        return abruptOr.Value;
+    }
+
     // 6.2.4.2 ThrowCompletion ( value ), https://tc39.es/ecma262/#sec-throwcompletion
     static public Completion ThrowCompletion(Value value)
     {

--- a/JSS.Lib/JSS.Lib.csproj
+++ b/JSS.Lib/JSS.Lib.csproj
@@ -16,4 +16,8 @@
             <_Parameter1>JSS.Benchmarks</_Parameter1>
         </AssemblyAttribute>
     </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="OneOf" Version="3.0.263" />
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
AbruptOr is useful for spec functions that can return a throw completion but can also only return one specific value.