### PR TITLE
Support the undefined property of the GlobalObject

### DIFF
--- a/JSS.Lib/AST/Values/Object.cs
+++ b/JSS.Lib/AST/Values/Object.cs
@@ -2,22 +2,6 @@
 
 namespace JSS.Lib.AST.Values;
 
-// 6.1.7.1 Property Attributes, https://tc39.es/ecma262/#sec-property-attributes
-// FIXME: [[Value]], [[Get]] [[Set]]
-internal sealed record Attributes(bool Writable, bool Enumerable, bool Configurable);
-
-internal sealed class Property
-{
-    public Property(Value value, Attributes attributes)
-    {
-        Value = value;
-        Attributes = attributes;
-    }
-
-    public Value Value { get; set; }
-    public Attributes Attributes { get; }
-}
-
 // 6.1.7 The Object Type, https://tc39.es/ecma262/#sec-object-type
 public class Object : Value
 {

--- a/JSS.Lib/AST/Values/Object.cs
+++ b/JSS.Lib/AST/Values/Object.cs
@@ -91,7 +91,7 @@ public class Object : Value
         return asCallable.Call(vm, V, (argumentsList as List)!);
     }
 
-    // 10.1.5 [[GetOwnProperty]] ( P )
+    // 10.1.5 [[GetOwnProperty]] ( P ), https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p
     internal Completion GetOwnProperty(string P)
     {
         // 1. Return OrdinaryGetOwnProperty(O, P).
@@ -119,7 +119,7 @@ public class Object : Value
         // FIXME: 6. Set D.[[Enumerable]] to the value of X's [[Enumerable]] attribute.
         // FIXME: 7. Set D.[[Configurable]] to the value of X's [[Configurable]] attribute.
         // FIXME: 8. Return D.
-        return O.DataProperties[P].Value;
+        return O.DataProperties[P];
     }
 
     // 10.1.6 [[DefineOwnProperty]] ( P, Desc ), https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc

--- a/JSS.Lib/AST/Values/Property.cs
+++ b/JSS.Lib/AST/Values/Property.cs
@@ -1,0 +1,21 @@
+﻿namespace JSS.Lib.AST.Values;
+
+// 6.1.7.1 Property Attributes, https://tc39.es/ecma262/#sec-property-attributes
+// FIXME: [[Get]] [[Set]]
+internal sealed record Attributes(bool Writable, bool Enumerable, bool Configurable);
+
+// 6.2.6 The Property Descriptor Specification Type, https://tc39.es/ecma262/#sec-property-descriptor-specification-type
+internal sealed class Property : Value
+{
+    public Property(Value value, Attributes attributes)
+    {
+        Value = value;
+        Attributes = attributes;
+    }
+
+    override public bool IsProperty() { return true; }
+    override public ValueType Type() { throw new InvalidOperationException("Tried to get the Type of Property"); }
+
+    public Value Value { get; set; }
+    public Attributes Attributes { get; }
+}

--- a/JSS.Lib/AST/Values/Value.cs
+++ b/JSS.Lib/AST/Values/Value.cs
@@ -13,7 +13,8 @@ public enum ValueType
     Number,
     BigInt,
     Object,
-    Function
+    Function,
+    Property
 }
 
 // FIXME: This is a very inefficient way of storing JS values.
@@ -36,6 +37,7 @@ public abstract class Value
     virtual public bool IsBigInt() { return false; }
     virtual public bool IsObject() { return false; }
     virtual public bool IsFunction() { return false; }
+    virtual public bool IsProperty() { return false; }
 
     public Reference AsReference()
     {

--- a/JSS.Lib/Execution/Realm.cs
+++ b/JSS.Lib/Execution/Realm.cs
@@ -88,6 +88,11 @@ public sealed class Realm
     {
         Dictionary<string, Property> globalProperties = new();
 
+        // 19.1 Value Properties of the Global Object
+        // 19.1.4 undefined
+        globalProperties.Add("undefined", new Property(Undefined.The, new(false, false, false)));
+
+        // 19.3 Constructor Properties of the Global Object
         // 20.1.1 The Object Constructor, https://tc39.es/ecma262/#sec-object-constructor
         globalProperties.Add("Object", new Property(ObjectConstructor.The, new(true, false, true)));
 


### PR DESCRIPTION
We now support the undefined property on the GlobalObject.

This allows the value of undefined to be used within our AST.

For example:
```js
if (x === undefined)
{
    // Do something if undefined
}
```

is now supported