### PR TITLE
bug: If property doesn't exist on object, don't throw KeyNotFoundException

### DIFF
--- a/JSS.Lib.UnitTests/ASTTests.cs
+++ b/JSS.Lib.UnitTests/ASTTests.cs
@@ -848,6 +848,38 @@ internal sealed class ASTTests
         shouldBeTrue!.Value.Should().BeTrue();
     }
 
+    [Test]
+    public void Properties_ShouldReturnUndefined_WhenReferecingProperty_ThatDoesntExist()
+    {
+        // Arrange
+        var script = ParseScript("let a = {}; a.b");
+
+        // Act
+        var actualCompletion = script.ScriptEvaluation();
+
+        // Assert
+        actualCompletion.IsNormalCompletion().Should().BeTrue();
+
+        var shouldBeTrue = actualCompletion.Value as Undefined;
+        shouldBeTrue.Should().NotBeNull();
+    }
+
+    [Test]
+    public void ComputedProperties_ShouldReturnUndefined_WhenReferecingProperty_ThatDoesntExist()
+    {
+        // Arrange
+        var script = ParseScript("let a = {}; a[\"b\"]");
+
+        // Act
+        var actualCompletion = script.ScriptEvaluation();
+
+        // Assert
+        actualCompletion.IsNormalCompletion().Should().BeTrue();
+
+        var shouldBeTrue = actualCompletion.Value as Undefined;
+        shouldBeTrue.Should().NotBeNull();
+    }
+
     // FIXME: We should have a different file for runtime tests
     [Test]
     public void TypeOf_ObjectConstructor_ReturnsAString_EqualToFunction()

--- a/JSS.Lib/AST/Values/Object.cs
+++ b/JSS.Lib/AST/Values/Object.cs
@@ -172,11 +172,18 @@ public class Object : Value
     // 10.1.8.1 OrdinaryGet ( O, P, Receiver ), https://tc39.es/ecma262/#sec-ordinaryget
     static internal Completion OrdinaryGet(Object O, string P, Object receiver)
     {
-        // FIXME: 1. Let desc be ? O.[[GetOwnProperty]](P).
-        // FIXME: 2. If desc is undefined, then
-        // FIXME: a. Let parent be ? O.[[GetPrototypeOf]]().
-        // FIXME: b. If parent is null, return undefined.
-        // FIXME: c. Return ? parent.[[Get]](P, Receiver).
+        // 1. Let desc be ? O.[[GetOwnProperty]](P).
+        var desc = O.GetOwnProperty(P);
+        if (desc.IsAbruptCompletion()) return desc;
+
+        // 2. If desc is undefined, then
+        if (desc.Value.IsUndefined())
+        {
+            // FIXME: a. Let parent be ? O.[[GetPrototypeOf]]().
+            // FIXME: b. If parent is null, return undefined.
+            // FIXME: c. Return ? parent.[[Get]](P, Receiver).
+            return Undefined.The;
+        }
 
         // FIXME: 3. If IsDataDescriptor(desc) is true, return desc.[[Value]].
         return O.DataProperties[P].Value;


### PR DESCRIPTION
The spec says to check if the descriptor is undefined when calling OrdinaryGet. Before this commit, we always tried to get the property from the internal dictionary.

This would cause internal errors, throwing a KeyNotFoundException if the property did not exist on the object.