### PR TITLE
Add support for function expression parsing and execution

### DIFF
--- a/JSS.Lib.UnitTests/ASTTests.cs
+++ b/JSS.Lib.UnitTests/ASTTests.cs
@@ -1310,6 +1310,20 @@ internal sealed class ASTTests
         completion.Value.Should().Be(new String($"{identifier} is not defined"));
     }
 
+    [Test]
+    public void AssignmentExpreesion_ToFunctionExpression_SetsIdentifier_ToFunction()
+    {
+        // Arrange
+        var script = ParseScript("a = function() { return 1 }; a()");
+
+        // Act
+        var completion = script.ScriptEvaluation();
+
+        // Assert
+        completion.IsNormalCompletion().Should().BeTrue();
+        completion.Value.Should().Be(new Number(1));
+    }
+
     static private string EscapeString(string toEscape, char quote = '"')
     {
         return $"{quote}{toEscape}{quote}";

--- a/JSS.Lib.UnitTests/ParserTests.cs
+++ b/JSS.Lib.UnitTests/ParserTests.cs
@@ -1132,6 +1132,66 @@ internal sealed class ParserTests
         parameters[0].Name.Should().Be(expectedParameterIdentifier);
     }
 
+    // NOTE: Function expressions cannot be expression statements, so we have to also have an a node that parses an expression
+    [Test]
+    public void Parse_ReturnsAssignmentExpression_WithFunctionExpression_WhenProvidingAssignmentWithAFunctionExpression()
+    {
+        // Arrange
+        var parser = new Parser($"a = function() {{}}");
+
+        // Act
+        var parsedProgram = ParseScript(parser);
+        var rootNodes = parsedProgram.ScriptCode;
+
+        // Assert
+        rootNodes.Should().HaveCount(1);
+
+        var expressionStatement = rootNodes[0] as ExpressionStatement;
+        expressionStatement.Should().NotBeNull();
+
+        var assignmentExpression = expressionStatement!.Expression as BasicAssignmentExpression;
+        assignmentExpression.Should().NotBeNull();
+
+        var functionExpression = assignmentExpression!.Rhs as FunctionExpression;
+        functionExpression.Should().NotBeNull();
+        functionExpression!.Identifier.Should().BeNull();
+        functionExpression.Body.Statements.Should().BeEmpty();
+
+        var parameters = functionExpression.Parameters;
+        parameters.Should().BeEmpty();
+    }
+
+    [Test]
+    public void Parse_ReturnsAssignmentExpression_WithFunctionExpression_WithAName_WhenProvidingAssignmentWithAFunctionExpression_WithAName()
+    {
+        // Arrange
+        const string expectedFunctionIdentifier = "expectedIdentifier";
+        const string expectedParameterIdentifier = "expectedFirstParameter";
+        var parser = new Parser($"a = function {expectedFunctionIdentifier}({expectedParameterIdentifier}) {{}}");
+
+        // Act
+        var parsedProgram = ParseScript(parser);
+        var rootNodes = parsedProgram.ScriptCode;
+
+        // Assert
+        rootNodes.Should().HaveCount(1);
+
+        var expressionStatement = rootNodes[0] as ExpressionStatement;
+        expressionStatement.Should().NotBeNull();
+
+        var assignmentExpression = expressionStatement!.Expression as BasicAssignmentExpression;
+        assignmentExpression.Should().NotBeNull();
+
+        var functionExpression = assignmentExpression!.Rhs as FunctionExpression;
+        functionExpression.Should().NotBeNull();
+        functionExpression!.Identifier.Should().Be(expectedFunctionIdentifier);
+        functionExpression.Body.Statements.Should().BeEmpty();
+
+        var parameters = functionExpression.Parameters;
+        parameters.Should().HaveCount(1);
+        parameters[0].Name.Should().Be(expectedParameterIdentifier);
+    }
+
     // Tests for 15.7 Class Definitions, https://tc39.es/ecma262/#sec-class-definitions
     [Test]
     public void Parse_ReturnsEmptyClassDeclaration_WhenProvidingEmptyClass()

--- a/JSS.Lib/AST/FunctionExpression.cs
+++ b/JSS.Lib/AST/FunctionExpression.cs
@@ -1,0 +1,18 @@
+﻿namespace JSS.Lib.AST;
+
+// 15.2 Function Definitions, https://tc39.es/ecma262/#sec-function-definitions
+internal sealed class FunctionExpression : IExpression
+{
+    public FunctionExpression(string? identifier, List<Identifier> parameters, StatementList body)
+    {
+        Identifier = identifier;
+        Parameters = parameters;
+        Body = body;
+    }
+
+    // FIXME: 15.2.6 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-function-definitions-runtime-semantics-evaluation
+
+    public string? Identifier { get; }
+    public IReadOnlyList<Identifier> Parameters { get; }
+    public StatementList Body { get; }
+}

--- a/JSS.Lib/AST/FunctionExpression.cs
+++ b/JSS.Lib/AST/FunctionExpression.cs
@@ -1,4 +1,7 @@
-﻿namespace JSS.Lib.AST;
+﻿using JSS.Lib.AST.Values;
+using JSS.Lib.Execution;
+
+namespace JSS.Lib.AST;
 
 // 15.2 Function Definitions, https://tc39.es/ecma262/#sec-function-definitions
 internal sealed class FunctionExpression : IExpression
@@ -10,7 +13,80 @@ internal sealed class FunctionExpression : IExpression
         Body = body;
     }
 
-    // FIXME: 15.2.6 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-function-definitions-runtime-semantics-evaluation
+    // 15.2.6 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-function-definitions-runtime-semantics-evaluation
+    public override Completion Evaluate(VM vm)
+    {
+        // 1. Return InstantiateOrdinaryFunctionExpression of FunctionExpression.
+        if (Identifier is null)
+        {
+            return InstantiateOrdinaryFunctionExpressionWithNoName(vm);
+        }
+        else
+        {
+            return InstantiateOrdinaryFunctionExpression(vm);
+        }
+    }
+
+    // 15.2.5 Runtime Semantics: InstantiateOrdinaryFunctionExpression, https://tc39.es/ecma262/#sec-runtime-semantics-instantiateordinaryfunctionexpression
+    private Completion InstantiateOrdinaryFunctionExpressionWithNoName(VM vm, string? name = null)
+    {
+        // 1. If name is not present, set name to "".
+        name ??= "";
+
+        // 2. Let env be the LexicalEnvironment of the running execution context.
+        var env = (vm.CurrentExecutionContext as ScriptExecutionContext)!.LexicalEnvironment;
+
+        // FIXME: 3. Let privateEnv be the running execution context's PrivateEnvironment.
+
+        // FIXME: 4. Let sourceText be the source text matched by FunctionExpression.
+
+        // 5. Let closure be OrdinaryFunctionCreate(%Function.prototype%, sourceText, FormalParameters, FunctionBody, NON-LEXICAL-THIS, env, privateEnv).
+        var closure = FunctionObject.OrdinaryFunctionCreate(Parameters, Body, LexicalThisMode.NON_LEXICAL_THIS, env!);
+
+        // 6. Perform SetFunctionName(closure, name).
+        closure.SetFunctionName(name);
+
+        // 7. Perform MakeConstructor(closure).
+        closure.MakeConstructor();
+
+        // 8. Return closure.
+        return closure;
+    }
+
+    private Completion InstantiateOrdinaryFunctionExpression(VM vm)
+    {
+        // 1. Assert: name is not present.
+        // 2. Set name to StringValue of BindingIdentifier.
+        var name = Identifier!;
+
+        // 3. Let outerEnv be the running execution context's LexicalEnvironment.
+        var outerEnv = (vm.CurrentExecutionContext as ScriptExecutionContext)!.LexicalEnvironment;
+
+        // 4. Let funcEnv be NewDeclarativeEnvironment(outerEnv).
+        var funcEnv = new DeclarativeEnvironment(outerEnv);
+
+        // 5. Perform ! funcEnv.CreateImmutableBinding(name, false).
+        MUST(funcEnv.CreateImmutableBinding(name, false));
+
+        // FIXME: 6. Let privateEnv be the running execution context's PrivateEnvironment.
+
+        // FIXME: 7. Let sourceText be the source text matched by FunctionExpression.
+
+        // 8. Let closure be OrdinaryFunctionCreate(%Function.prototype%, sourceText, FormalParameters, FunctionBody, NON-LEXICAL-THIS, funcEnv, privateEnv).
+        var closure = FunctionObject.OrdinaryFunctionCreate(Parameters, Body, LexicalThisMode.NON_LEXICAL_THIS, funcEnv);
+
+        // 9. Perform SetFunctionName(closure, name).
+        closure.SetFunctionName(name);
+
+        // 10. Perform MakeConstructor(closure).
+        closure.MakeConstructor();
+
+        // 11. Perform ! funcEnv.InitializeBinding(name, closure).
+        MUST(funcEnv.InitializeBinding(name, closure));
+
+        // 12. Return closure.
+        return closure;
+    }
 
     public string? Identifier { get; }
     public IReadOnlyList<Identifier> Parameters { get; }


### PR DESCRIPTION
We can now parse and execute function expressions according to the spec.

This is used in test-262 in the assert.js, so we improve the support for eventually running test-262.

Example Code:
```js
let factClosure = function fact(n)
{
    if (n == 0) return 1;
    return n * fact(n - 1);
}

factClosure(4); // Returns 4! => 24
```