### PR TITLE
Add support for binding values to catch parameters

### DIFF
--- a/JSS.Lib.UnitTests/ASTTests.cs
+++ b/JSS.Lib.UnitTests/ASTTests.cs
@@ -330,6 +330,10 @@ internal sealed class ASTTests
         CreateTryStatementTestCase("throw 1", "throw 2", "throw 3", 3, CompletionType.Throw),
         CreateTryStatementTestCase("1", "2", "throw 3", 3, CompletionType.Throw),
 
+        // Tests for TryStatements with a catch parameter
+        CreateTryCatchParameterTestCase("throw 1", "err", "err", 1, CompletionType.Normal),
+        CreateTryCatchParameterTestCase("throw 1", "err", "throw err", 1, CompletionType.Throw),
+
         // Tests for PostfixDecrementExpression
         CreatePostfixDecrementExpressionTestCase("null", 0),
         CreatePostfixDecrementExpressionTestCase("false", 0),
@@ -627,6 +631,12 @@ internal sealed class ASTTests
             testCode += $"finally {{ {finallyCode} }}";
         }
 
+        return new object[] { testCode, new Completion(type, expected, "") };
+    }
+
+    static private object[] CreateTryCatchParameterTestCase(string tryCode, string parameter, string catchCode, Value expected, CompletionType type)
+    {
+        string testCode = $"try {{ {tryCode} }} catch ({parameter}) {{ {catchCode} }}";
         return new object[] { testCode, new Completion(type, expected, "") };
     }
 

--- a/JSS.Lib/AST/Identifier.cs
+++ b/JSS.Lib/AST/Identifier.cs
@@ -1,4 +1,5 @@
-﻿using JSS.Lib.Execution;
+﻿using JSS.Lib.AST.Values;
+using JSS.Lib.Execution;
 
 namespace JSS.Lib.AST;
 
@@ -15,6 +16,14 @@ internal sealed class Identifier : IExpression
     {
         // 1. Return a List whose sole element is the StringValue of Identifier.
         return new List<string> { Name };
+    }
+
+    // 8.6.2 Runtime Semantics: BindingInitialization, https://tc39.es/ecma262/#sec-runtime-semantics-bindinginitialization
+    public Completion BindingInitialization(VM vm, Value value, Value environment)
+    {
+        // 1. Let name be StringValue of Identifier.
+        // 2. Return ? InitializeBoundName(name, value, environment).
+        return ScriptExecutionContext.InitializeBoundName(vm, Name, value, environment);
     }
 
     // 13.1.3 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-identifiers-runtime-semantics-evaluation


### PR DESCRIPTION
We now support catch parameters in our AST.

Example Code:
```js
try
{
    throw x;
}
catch (err)
{
    err; // err holds the value of x
}
```