### PR TITLE
Implement basic support for the %Function.prototype%

### DIFF
--- a/JSS.Lib/AST/FunctionDeclaration.cs
+++ b/JSS.Lib/AST/FunctionDeclaration.cs
@@ -1,5 +1,6 @@
 ﻿using JSS.Lib.AST.Values;
 using JSS.Lib.Execution;
+using JSS.Lib.Runtime;
 
 namespace JSS.Lib.AST;
 
@@ -30,8 +31,8 @@ internal sealed class FunctionDeclaration : Declaration
 
         // FIXME: 2. Let sourceText be the source text matched by FunctionDeclaration.
 
-        // FIXME: 3. Let F be OrdinaryFunctionCreate(%Function.prototype%, sourceText, FormalParameters, FunctionBody, NON-LEXICAL-THIS, env, privateEnv).
-        var F = FunctionObject.OrdinaryFunctionCreate(Parameters, Body, LexicalThisMode.NON_LEXICAL_THIS, env);
+        // FIXME: 3. Let F be OrdinaryFunctionCreate(FIXME: %Function.prototype%, sourceText, FormalParameters, FunctionBody, NON-LEXICAL-THIS, env, privateEnv).
+        var F = FunctionObject.OrdinaryFunctionCreate(ObjectPrototype.The, Parameters, Body, LexicalThisMode.NON_LEXICAL_THIS, env);
 
         // 4. Perform SetFunctionName(F, name).
         F.SetFunctionName(Identifier);

--- a/JSS.Lib/AST/FunctionDeclaration.cs
+++ b/JSS.Lib/AST/FunctionDeclaration.cs
@@ -31,8 +31,8 @@ internal sealed class FunctionDeclaration : Declaration
 
         // FIXME: 2. Let sourceText be the source text matched by FunctionDeclaration.
 
-        // FIXME: 3. Let F be OrdinaryFunctionCreate(FIXME: %Function.prototype%, sourceText, FormalParameters, FunctionBody, NON-LEXICAL-THIS, env, privateEnv).
-        var F = FunctionObject.OrdinaryFunctionCreate(ObjectPrototype.The, Parameters, Body, LexicalThisMode.NON_LEXICAL_THIS, env);
+        // FIXME: 3. Let F be OrdinaryFunctionCreate(%Function.prototype%, sourceText, FormalParameters, FunctionBody, NON-LEXICAL-THIS, env, privateEnv).
+        var F = FunctionObject.OrdinaryFunctionCreate(FunctionPrototype.The, Parameters, Body, LexicalThisMode.NON_LEXICAL_THIS, env);
 
         // 4. Perform SetFunctionName(F, name).
         F.SetFunctionName(Identifier);

--- a/JSS.Lib/AST/FunctionExpression.cs
+++ b/JSS.Lib/AST/FunctionExpression.cs
@@ -41,8 +41,8 @@ internal sealed class FunctionExpression : IExpression
 
         // FIXME: 4. Let sourceText be the source text matched by FunctionExpression.
 
-        // 5. Let closure be OrdinaryFunctionCreate(FIXME: %Function.prototype%, sourceText, FormalParameters, FunctionBody, NON-LEXICAL-THIS, env, privateEnv).
-        var closure = FunctionObject.OrdinaryFunctionCreate(ObjectPrototype.The, Parameters, Body, LexicalThisMode.NON_LEXICAL_THIS, env!);
+        // 5. Let closure be OrdinaryFunctionCreate(%Function.prototype%, sourceText, FormalParameters, FunctionBody, NON-LEXICAL-THIS, env, privateEnv).
+        var closure = FunctionObject.OrdinaryFunctionCreate(FunctionPrototype.The, Parameters, Body, LexicalThisMode.NON_LEXICAL_THIS, env!);
 
         // 6. Perform SetFunctionName(closure, name).
         closure.SetFunctionName(name);
@@ -73,8 +73,8 @@ internal sealed class FunctionExpression : IExpression
 
         // FIXME: 7. Let sourceText be the source text matched by FunctionExpression.
 
-        // 8. Let closure be OrdinaryFunctionCreate(FIXME: %Function.prototype%, sourceText, FormalParameters, FunctionBody, NON-LEXICAL-THIS, funcEnv, privateEnv).
-        var closure = FunctionObject.OrdinaryFunctionCreate(ObjectPrototype.The, Parameters, Body, LexicalThisMode.NON_LEXICAL_THIS, funcEnv);
+        // 8. Let closure be OrdinaryFunctionCreate(%Function.prototype%, sourceText, FormalParameters, FunctionBody, NON-LEXICAL-THIS, funcEnv, privateEnv).
+        var closure = FunctionObject.OrdinaryFunctionCreate(FunctionPrototype.The, Parameters, Body, LexicalThisMode.NON_LEXICAL_THIS, funcEnv);
 
         // 9. Perform SetFunctionName(closure, name).
         closure.SetFunctionName(name);

--- a/JSS.Lib/AST/FunctionExpression.cs
+++ b/JSS.Lib/AST/FunctionExpression.cs
@@ -1,5 +1,6 @@
 ﻿using JSS.Lib.AST.Values;
 using JSS.Lib.Execution;
+using JSS.Lib.Runtime;
 
 namespace JSS.Lib.AST;
 
@@ -40,8 +41,8 @@ internal sealed class FunctionExpression : IExpression
 
         // FIXME: 4. Let sourceText be the source text matched by FunctionExpression.
 
-        // 5. Let closure be OrdinaryFunctionCreate(%Function.prototype%, sourceText, FormalParameters, FunctionBody, NON-LEXICAL-THIS, env, privateEnv).
-        var closure = FunctionObject.OrdinaryFunctionCreate(Parameters, Body, LexicalThisMode.NON_LEXICAL_THIS, env!);
+        // 5. Let closure be OrdinaryFunctionCreate(FIXME: %Function.prototype%, sourceText, FormalParameters, FunctionBody, NON-LEXICAL-THIS, env, privateEnv).
+        var closure = FunctionObject.OrdinaryFunctionCreate(ObjectPrototype.The, Parameters, Body, LexicalThisMode.NON_LEXICAL_THIS, env!);
 
         // 6. Perform SetFunctionName(closure, name).
         closure.SetFunctionName(name);
@@ -72,8 +73,8 @@ internal sealed class FunctionExpression : IExpression
 
         // FIXME: 7. Let sourceText be the source text matched by FunctionExpression.
 
-        // 8. Let closure be OrdinaryFunctionCreate(%Function.prototype%, sourceText, FormalParameters, FunctionBody, NON-LEXICAL-THIS, funcEnv, privateEnv).
-        var closure = FunctionObject.OrdinaryFunctionCreate(Parameters, Body, LexicalThisMode.NON_LEXICAL_THIS, funcEnv);
+        // 8. Let closure be OrdinaryFunctionCreate(FIXME: %Function.prototype%, sourceText, FormalParameters, FunctionBody, NON-LEXICAL-THIS, funcEnv, privateEnv).
+        var closure = FunctionObject.OrdinaryFunctionCreate(ObjectPrototype.The, Parameters, Body, LexicalThisMode.NON_LEXICAL_THIS, funcEnv);
 
         // 9. Perform SetFunctionName(closure, name).
         closure.SetFunctionName(name);

--- a/JSS.Lib/AST/Values/BuiltinFunction.cs
+++ b/JSS.Lib/AST/Values/BuiltinFunction.cs
@@ -67,8 +67,8 @@ internal sealed class BuiltinFunction : Object, ICallable, IConstructable
         // 1. If realm is not present, set realm to the current Realm Record.
         realm ??= vm.Realm;
 
-        // 2. If prototype is not present, set prototype to realm.[[Intrinsics]]. FIXME: [[%Function.prototype%]].
-        prototype ??= ObjectPrototype.The;
+        // 2. If prototype is not present, set prototype to realm.[[Intrinsics]].[[%Function.prototype%]].
+        prototype ??= FunctionPrototype.The;
 
         // 3. Let internalSlotsList be a List containing the names of all the internal slots that 10.3 requires for the built-in function object that is about to be created.
 

--- a/JSS.Lib/AST/Values/FunctionObject.cs
+++ b/JSS.Lib/AST/Values/FunctionObject.cs
@@ -339,7 +339,8 @@ internal sealed class FunctionObject : Object, ICallable, IConstructable
             // FIXME: b. Perform ! DefinePropertyOrThrow(prototype, "constructor", PropertyDescriptor { [[Value]]: F, [[Writable]]: writablePrototype, [[Enumerable]]: false, [[Configurable]]: true }).
         }
 
-        // FIXME: 6. Perform ! DefinePropertyOrThrow(F, "prototype", PropertyDescriptor { [[Value]]: prototype, [[Writable]]: writablePrototype, [[Enumerable]]: false, [[Configurable]]: false }).
+        // 6. Perform ! DefinePropertyOrThrow(F, "prototype", PropertyDescriptor { [[Value]]: prototype, [[Writable]]: writablePrototype, [[Enumerable]]: false, [[Configurable]]: false }).
+        MUST(DefinePropertyOrThrow(this, "prototype", new(prototype, new(writiablePrototype.Value, false, false))));
 
         // 7. Return UNUSED.
     }

--- a/JSS.Lib/AST/Values/FunctionObject.cs
+++ b/JSS.Lib/AST/Values/FunctionObject.cs
@@ -336,7 +336,8 @@ internal sealed class FunctionObject : Object, ICallable, IConstructable
             // a. Set prototype to OrdinaryObjectCreate(%Object.prototype%).
             prototype = new Object(ObjectPrototype.The);
 
-            // FIXME: b. Perform ! DefinePropertyOrThrow(prototype, "constructor", PropertyDescriptor { [[Value]]: F, [[Writable]]: writablePrototype, [[Enumerable]]: false, [[Configurable]]: true }).
+            // b. Perform ! DefinePropertyOrThrow(prototype, "constructor", PropertyDescriptor { [[Value]]: F, [[Writable]]: writablePrototype, [[Enumerable]]: false, [[Configurable]]: true }).
+            MUST(DefinePropertyOrThrow(prototype, "constructor", new(this, new(writiablePrototype.Value, false, true))));
         }
 
         // 6. Perform ! DefinePropertyOrThrow(F, "prototype", PropertyDescriptor { [[Value]]: prototype, [[Writable]]: writablePrototype, [[Enumerable]]: false, [[Configurable]]: false }).

--- a/JSS.Lib/AST/Values/FunctionObject.cs
+++ b/JSS.Lib/AST/Values/FunctionObject.cs
@@ -248,12 +248,13 @@ internal sealed class FunctionObject : Object, ICallable, IConstructable
     }
 
     // 10.2.3 OrdinaryFunctionCreate ( FIXME: functionPrototype, FIXME: sourceText, ParameterList, Body, thisMode, env, FIXME: privateEnv ), https://tc39.es/ecma262/#sec-ordinaryfunctioncreate
-    static public FunctionObject OrdinaryFunctionCreate(IReadOnlyList<Identifier> parameterList, StatementList body, LexicalThisMode thisMode, Environment env)
+    static public FunctionObject OrdinaryFunctionCreate(Object functionPrototype, IReadOnlyList<Identifier> parameterList, StatementList body, LexicalThisMode thisMode,
+        Environment env)
     {
         // 1. Let internalSlotsList be the internal slots listed in Table 30.
 
-        // FIXME: 2. Let F be OrdinaryObjectCreate(functionPrototype, internalSlotsList).
-        var f = new FunctionObject(null);
+        // 2. Let F be OrdinaryObjectCreate(functionPrototype, internalSlotsList).
+        var f = new FunctionObject(functionPrototype);
 
         // 3. Set F.[[Call]] to the definition specified in 10.2.1.
 

--- a/JSS.Lib/Runtime/Function.prototype.cs
+++ b/JSS.Lib/Runtime/Function.prototype.cs
@@ -1,0 +1,19 @@
+﻿namespace JSS.Lib.Runtime;
+
+// 20.2.3 Properties of the Function Prototype Object, https://tc39.es/ecma262/#sec-properties-of-the-function-prototype-object
+internal sealed class FunctionPrototype : Object
+{
+    // The Function prototype has a [[Prototype]] internal slot whose value is %Object.prototype%.
+    public FunctionPrototype() : base(ObjectPrototype.The)
+    {
+    }
+
+    static public FunctionPrototype The
+    {
+        get
+        {
+            return _prototype;
+        }
+    }
+    static readonly private FunctionPrototype _prototype = new();
+}

--- a/JSS.Lib/Runtime/Object.constructor.cs
+++ b/JSS.Lib/Runtime/Object.constructor.cs
@@ -3,10 +3,11 @@ using JSS.Lib.Execution;
 
 namespace JSS.Lib.Runtime;
 
+// 20.1.2 Properties of the Object Constructor, https://tc39.es/ecma262/#sec-object-value
 internal class ObjectConstructor : Object, ICallable, IConstructable
 {
-    // FIXME: The Object constructor has a [[Prototype]] internal slot whose value is %Function.prototype%.
-    private ObjectConstructor() : base(null)
+    // The Object constructor has a [[Prototype]] internal slot whose value is %Function.prototype%.
+    private ObjectConstructor() : base(FunctionPrototype.The)
     {
         // The Object constructor has a "length" property whose value is 1𝔽.
         // FIXME: We should probably have a method for internally defining properties


### PR DESCRIPTION
We now have basic support for the %Function.prototype% as defined in the spec.

Function objects now have their prototype set to the %Function.prototype%.