### PR TITLE
Add support for traversing parents for Objects for properties

### DIFF
--- a/JSS.Lib/AST/Values/Object.cs
+++ b/JSS.Lib/AST/Values/Object.cs
@@ -201,10 +201,14 @@ public class Object : Value
         // 2. If desc is undefined, then
         if (desc.Value.IsUndefined())
         {
-            // FIXME: a. Let parent be ? O.[[GetPrototypeOf]]().
-            // FIXME: b. If parent is null, return undefined.
-            // FIXME: c. Return ? parent.[[Get]](P, Receiver).
-            return Undefined.The;
+            // a. Let parent be ? O.[[GetPrototypeOf]]().
+            var parent = O.GetPrototypeOf();
+
+            // b. If parent is null, return undefined.
+            if (parent is null) return Undefined.The;
+
+            // c. Return ? parent.[[Get]](P, Receiver).
+            return parent.Get(P, receiver);
         }
 
         // FIXME: 3. If IsDataDescriptor(desc) is true, return desc.[[Value]].

--- a/JSS.Lib/AST/Values/Object.cs
+++ b/JSS.Lib/AST/Values/Object.cs
@@ -170,9 +170,15 @@ public class Object : Value
         //  2. If hasOwn is not undefined, return true.
         if (!hasOwn.Value.IsUndefined()) return true;
 
-        // FIXME: 3. Let parent be ? O.[[GetPrototypeOf]]().
-        // FIXME: 4. If parent is not null, then
-        // FIXME: a. Return ? parent.[[HasProperty]](P).
+        // 3. Let parent be ? O.[[GetPrototypeOf]]().
+        var parent = O.GetPrototypeOf();
+
+        // 4. If parent is not null, then
+        if (parent is not null)
+        {
+            // a. Return ? parent.[[HasProperty]](P).
+            return parent.HasProperty(P);
+        }
 
         // 5. Return false.
         return false;

--- a/JSS.Lib/AST/Values/Object.cs
+++ b/JSS.Lib/AST/Values/Object.cs
@@ -7,7 +7,7 @@ public class Object : Value
 {
     internal Object(Object? prototype)
     {
-        Prototype = prototype ?? this;
+        Prototype = prototype;
         DataProperties = new();
     }
 
@@ -89,6 +89,20 @@ public class Object : Value
         // 3. Return ? F.[[Call]](V, argumentsList).
         var asCallable = F.AsCallable(); 
         return asCallable.Call(vm, V, (argumentsList as List)!);
+    }
+
+    // 10.1.1 [[GetPrototypeOf]] ( ), https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof
+    internal Object? GetPrototypeOf()
+    {
+        // 1. Return OrdinaryGetPrototypeOf(O).
+        return OrdinaryGetPrototypeOf(this);
+    }
+
+    // 10.1.1.1 OrdinaryGetPrototypeOf ( O ), https://tc39.es/ecma262/#sec-ordinarygetprototypeof
+    static internal Object? OrdinaryGetPrototypeOf(Object O)
+    {
+        // 1. Return O.[[Prototype]].
+        return O.Prototype;
     }
 
     // 10.1.5 [[GetOwnProperty]] ( P ), https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p
@@ -222,6 +236,6 @@ public class Object : Value
     }
 
     // FIXME: Accessor Attributes
-    internal Object Prototype { get; }
+    internal Object? Prototype { get; }
     internal Dictionary<string, Property> DataProperties { get; }
 }


### PR DESCRIPTION
This allows us to get properties defined on parent prototypes.
For example, the Object.prototype has a constructor property, this change allows us to get the constructor property from an object.

Example Code:
```js
var obj = {}
obj.constructor // Returns the constructor function
```