### PR TITLE
feat: Instantiate intrinsics per realm instead of using singletons

### DIFF
--- a/JSS.Lib/AST/Block.cs
+++ b/JSS.Lib/AST/Block.cs
@@ -21,7 +21,7 @@ internal sealed class Block : INode
         var blockEnv = new DeclarativeEnvironment(oldEnv);
 
         // 3. Perform BlockDeclarationInstantiation(StatementList, blockEnv).
-        BlockDeclarationInstantiation(blockEnv);
+        BlockDeclarationInstantiation(vm, blockEnv);
 
         // 4. Set the running execution context's LexicalEnvironment to blockEnv.
         currentExecutionContext.LexicalEnvironment = blockEnv;
@@ -37,7 +37,7 @@ internal sealed class Block : INode
     }
 
     // 14.2.3 BlockDeclarationInstantiation ( code, env ), https://tc39.es/ecma262/#sec-blockdeclarationinstantiation
-    private void BlockDeclarationInstantiation(DeclarativeEnvironment env)
+    private void BlockDeclarationInstantiation(VM vm, DeclarativeEnvironment env)
     {
         // 1. Let declarations be the LexicallyScopedDeclarations of code.
         var declarations = Statements.LexicallyScopedDeclarations();
@@ -72,7 +72,7 @@ internal sealed class Block : INode
 
                 // ii. Let fo be InstantiateFunctionObject of d with arguments env and privateEnv.
                 var f = d as FunctionDeclaration;
-                var fo = f!.InstantiateFunctionObject(env);
+                var fo = f!.InstantiateFunctionObject(vm, env);
 
                 // iii. Perform ! env.InitializeBinding(fn, fo). NOTE: This step is replaced in section B.3.2.6.
                 MUST(env.InitializeBinding(fn, fo));

--- a/JSS.Lib/AST/FunctionDeclaration.cs
+++ b/JSS.Lib/AST/FunctionDeclaration.cs
@@ -23,7 +23,7 @@ internal sealed class FunctionDeclaration : Declaration
     }
 
     // 8.6.1 Runtime Semantics: InstantiateFunctionObject, https://tc39.es/ecma262/#sec-runtime-semantics-instantiatefunctionobject
-    public FunctionObject InstantiateFunctionObject(Environment env)
+    public FunctionObject InstantiateFunctionObject(VM vm, Environment env)
     {
         // NOTE/FIXME: This is the steps for InstantiateOrdinaryFunctionObject
 
@@ -32,13 +32,13 @@ internal sealed class FunctionDeclaration : Declaration
         // FIXME: 2. Let sourceText be the source text matched by FunctionDeclaration.
 
         // FIXME: 3. Let F be OrdinaryFunctionCreate(%Function.prototype%, sourceText, FormalParameters, FunctionBody, NON-LEXICAL-THIS, env, privateEnv).
-        var F = FunctionObject.OrdinaryFunctionCreate(FunctionPrototype.The, Parameters, Body, LexicalThisMode.NON_LEXICAL_THIS, env);
+        var F = FunctionObject.OrdinaryFunctionCreate(vm.FunctionPrototype, Parameters, Body, LexicalThisMode.NON_LEXICAL_THIS, env);
 
         // 4. Perform SetFunctionName(F, name).
         F.SetFunctionName(Identifier);
 
         // 5. Perform MakeConstructor(F).
-        F.MakeConstructor();
+        F.MakeConstructor(vm);
 
         // 6. Return F.
         return F;

--- a/JSS.Lib/AST/FunctionExpression.cs
+++ b/JSS.Lib/AST/FunctionExpression.cs
@@ -42,13 +42,13 @@ internal sealed class FunctionExpression : IExpression
         // FIXME: 4. Let sourceText be the source text matched by FunctionExpression.
 
         // 5. Let closure be OrdinaryFunctionCreate(%Function.prototype%, sourceText, FormalParameters, FunctionBody, NON-LEXICAL-THIS, env, privateEnv).
-        var closure = FunctionObject.OrdinaryFunctionCreate(FunctionPrototype.The, Parameters, Body, LexicalThisMode.NON_LEXICAL_THIS, env!);
+        var closure = FunctionObject.OrdinaryFunctionCreate(vm.FunctionPrototype, Parameters, Body, LexicalThisMode.NON_LEXICAL_THIS, env!);
 
         // 6. Perform SetFunctionName(closure, name).
         closure.SetFunctionName(name);
 
         // 7. Perform MakeConstructor(closure).
-        closure.MakeConstructor();
+        closure.MakeConstructor(vm);
 
         // 8. Return closure.
         return closure;
@@ -74,13 +74,13 @@ internal sealed class FunctionExpression : IExpression
         // FIXME: 7. Let sourceText be the source text matched by FunctionExpression.
 
         // 8. Let closure be OrdinaryFunctionCreate(%Function.prototype%, sourceText, FormalParameters, FunctionBody, NON-LEXICAL-THIS, funcEnv, privateEnv).
-        var closure = FunctionObject.OrdinaryFunctionCreate(FunctionPrototype.The, Parameters, Body, LexicalThisMode.NON_LEXICAL_THIS, funcEnv);
+        var closure = FunctionObject.OrdinaryFunctionCreate(vm.FunctionPrototype, Parameters, Body, LexicalThisMode.NON_LEXICAL_THIS, funcEnv);
 
         // 9. Perform SetFunctionName(closure, name).
         closure.SetFunctionName(name);
 
         // 10. Perform MakeConstructor(closure).
-        closure.MakeConstructor();
+        closure.MakeConstructor(vm);
 
         // 11. Perform ! funcEnv.InitializeBinding(name, closure).
         MUST(funcEnv.InitializeBinding(name, closure));

--- a/JSS.Lib/AST/Literal/ObjectLiteral.cs
+++ b/JSS.Lib/AST/Literal/ObjectLiteral.cs
@@ -1,5 +1,4 @@
 ﻿using JSS.Lib.Execution;
-using JSS.Lib.Runtime;
 
 namespace JSS.Lib.AST.Literal;
 
@@ -11,6 +10,6 @@ internal class ObjectLiteral : IExpression
     {
         // FIXME: Implement the rest of the evaluation when we parse property definitions
         // 1. Return OrdinaryObjectCreate(%Object.prototype%).
-        return new Object(ObjectPrototype.The);
+        return new Object(vm.ObjectPrototype);
     }
 }

--- a/JSS.Lib/AST/Values/BuiltinFunction.cs
+++ b/JSS.Lib/AST/Values/BuiltinFunction.cs
@@ -68,7 +68,7 @@ internal sealed class BuiltinFunction : Object, ICallable, IConstructable
         realm ??= vm.Realm;
 
         // 2. If prototype is not present, set prototype to realm.[[Intrinsics]].[[%Function.prototype%]].
-        prototype ??= FunctionPrototype.The;
+        prototype ??= vm.FunctionPrototype;
 
         // 3. Let internalSlotsList be a List containing the names of all the internal slots that 10.3 requires for the built-in function object that is about to be created.
 

--- a/JSS.Lib/AST/Values/FunctionObject.cs
+++ b/JSS.Lib/AST/Values/FunctionObject.cs
@@ -187,7 +187,7 @@ internal sealed class FunctionObject : Object, ICallable, IConstructable
         if (ConstructorKind == ConstructorKind.BASE)
         {
             // a. Let thisArgument be ? FIXME: OrdinaryCreateFromConstructor(newTarget, "%Object.prototype%").
-            thisArgument = new Object(ObjectPrototype.The);
+            thisArgument = new Object(vm.ObjectPrototype);
         }
 
         // 4. Let calleeContext be PrepareForOrdinaryCall(F, FIXME: newTarget).
@@ -314,7 +314,7 @@ internal sealed class FunctionObject : Object, ICallable, IConstructable
     }
 
     // 10.2.5 MakeConstructor ( F [ , writablePrototype [ , prototype ] ] ), https://tc39.es/ecma262/#sec-makeconstructor
-    public void MakeConstructor(bool? writiablePrototype = null, Object? prototype = null)
+    public void MakeConstructor(VM vm, bool? writiablePrototype = null, Object? prototype = null)
     {
         // NOTE: This is implemented using inheritance so these steps are done at compile time
         // FIXME: 1. If F is an ECMAScript function object, then
@@ -334,7 +334,7 @@ internal sealed class FunctionObject : Object, ICallable, IConstructable
         if (prototype is null)
         {
             // a. Set prototype to OrdinaryObjectCreate(%Object.prototype%).
-            prototype = new Object(ObjectPrototype.The);
+            prototype = new Object(vm.ObjectPrototype);
 
             // b. Perform ! DefinePropertyOrThrow(prototype, "constructor", PropertyDescriptor { [[Value]]: F, [[Writable]]: writablePrototype, [[Enumerable]]: false, [[Configurable]]: true }).
             MUST(DefinePropertyOrThrow(prototype, "constructor", new(this, new(writiablePrototype.Value, false, true))));
@@ -630,7 +630,7 @@ internal sealed class FunctionObject : Object, ICallable, IConstructable
             var fn = f.BoundNames().FirstOrDefault()!;
 
             // b. Let fo be InstantiateFunctionObject of f with arguments lexEnv and privateEnv.
-            var fo = f.InstantiateFunctionObject(lexEnv);
+            var fo = f.InstantiateFunctionObject(vm, lexEnv);
 
             // c. Perform ! varEnv.SetMutableBinding(fn, fo, false).
             MUST(varEnv.SetMutableBinding(fn, fo, false));

--- a/JSS.Lib/Execution/Script.cs
+++ b/JSS.Lib/Execution/Script.cs
@@ -227,7 +227,7 @@ public sealed class Script
             var fn = f.BoundNames().FirstOrDefault()!;
 
             // b. Let fo be InstantiateFunctionObject of f with arguments env FIXME: and privateEnv.
-            var fo = f.InstantiateFunctionObject(env);
+            var fo = f.InstantiateFunctionObject(VM, env);
 
             // c. Perform ? env.CreateGlobalFunctionBinding(fn, fo, false).
             var createResult = env.CreateGlobalFunctionBinding(fn, fo, false);

--- a/JSS.Lib/Execution/VM.cs
+++ b/JSS.Lib/Execution/VM.cs
@@ -1,4 +1,6 @@
-﻿namespace JSS.Lib.Execution;
+﻿using JSS.Lib.Runtime;
+
+namespace JSS.Lib.Execution;
 
 // NOTE: This isn't required in the spec but is a helper for executing code
 public sealed class VM
@@ -24,6 +26,10 @@ public sealed class VM
     }
 
     public Realm Realm { get; }
+
+    internal ObjectPrototype ObjectPrototype { get => Realm.ObjectPrototype; }
+    internal ObjectConstructor ObjectConstructor { get => Realm.ObjectConstructor; }
+    internal FunctionPrototype FunctionPrototype { get => Realm.FunctionPrototype; }
 
     internal ExecutionContext CurrentExecutionContext
     {

--- a/JSS.Lib/Runtime/Function.prototype.cs
+++ b/JSS.Lib/Runtime/Function.prototype.cs
@@ -4,16 +4,7 @@
 internal sealed class FunctionPrototype : Object
 {
     // The Function prototype has a [[Prototype]] internal slot whose value is %Object.prototype%.
-    public FunctionPrototype() : base(ObjectPrototype.The)
+    public FunctionPrototype(ObjectPrototype objectPrototype) : base(objectPrototype)
     {
     }
-
-    static public FunctionPrototype The
-    {
-        get
-        {
-            return _prototype;
-        }
-    }
-    static readonly private FunctionPrototype _prototype = new();
 }

--- a/JSS.Lib/Runtime/Object.constructor.cs
+++ b/JSS.Lib/Runtime/Object.constructor.cs
@@ -7,7 +7,11 @@ namespace JSS.Lib.Runtime;
 internal class ObjectConstructor : Object, ICallable, IConstructable
 {
     // The Object constructor has a [[Prototype]] internal slot whose value is %Function.prototype%.
-    private ObjectConstructor() : base(FunctionPrototype.The)
+    public ObjectConstructor(FunctionPrototype prototype) : base(prototype)
+    {
+    }
+
+    public void Initialize()
     {
         // The Object constructor has a "length" property whose value is 1𝔽.
         // FIXME: We should probably have a method for internally defining properties
@@ -30,19 +34,10 @@ internal class ObjectConstructor : Object, ICallable, IConstructable
         var value = argumentList[0];
         if (value.IsUndefined() || value.IsNull())
         {
-            return new Object(ObjectPrototype.The);
+            return new Object(vm.ObjectPrototype);
         }
 
         // 3. Return ! ToObject(value).
         return MUST(value.ToObject());
     }
-
-    static public ObjectConstructor The
-    {
-        get
-        {
-            return _constructor;
-        }
-    }
-    static readonly private ObjectConstructor _constructor = new();
 }

--- a/JSS.Lib/Runtime/Object.prototype.cs
+++ b/JSS.Lib/Runtime/Object.prototype.cs
@@ -1,4 +1,5 @@
 ﻿using JSS.Lib.AST.Values;
+using JSS.Lib.Execution;
 
 namespace JSS.Lib.Runtime;
 
@@ -8,15 +9,10 @@ internal class ObjectPrototype : Object
     // The Object prototype object has a [[Prototype]] internal slot whose value is null.
     public ObjectPrototype() : base(null)
     {
-        DataProperties.Add("constructor", new Property(ObjectConstructor.The, new Attributes(true, false, true)));
     }
 
-    static public ObjectPrototype The
+    public void Initialize(Realm realm)
     {
-        get
-        {
-            return _prototype;
-        }
+        DataProperties.Add("constructor", new Property(realm.ObjectConstructor, new Attributes(true, false, true)));
     }
-    static readonly private ObjectPrototype _prototype = new();
 }


### PR DESCRIPTION
We now instantiate intrinsic (such as Object.prototype) per realm. This is done in the CreateIntrinsics spec function.

We deviate from the spec slightly, as we don't use a record and just have an instance variable per intrinsic on the realm.

This also means if there are two realms, someone changing an intrinsic is not visible on the other realm.