### PR TITLE
bug: Don't use reference when calling ToNumeric inside of UnaryMinus

### DIFF
--- a/JSS.Lib/AST/UnaryMinusExpression.cs
+++ b/JSS.Lib/AST/UnaryMinusExpression.cs
@@ -23,7 +23,7 @@ internal sealed class UnaryMinusExpression : IExpression
         var exprValue = expr.Value.GetValue();
         if (exprValue.IsAbruptCompletion()) return exprValue;
 
-        var oldValue = expr.Value.ToNumeric();
+        var oldValue = exprValue.Value.ToNumeric();
         if (oldValue.IsAbruptCompletion()) return oldValue;
 
         // 3. If oldValue is a Number, then


### PR DESCRIPTION
We would call ToNumeric on the number reference instead of the actual value of the reference.