### PR TITLE
JSS-3 Implement support for the JS String conversion constructor

### DIFF
--- a/JSS.Lib/Execution/Realm.cs
+++ b/JSS.Lib/Execution/Realm.cs
@@ -56,6 +56,8 @@ public sealed class Realm
         ObjectPrototype.Initialize(this);
         ObjectConstructor.Initialize();
 
+        StringConstructor = new(FunctionPrototype);
+
         ErrorPrototype = new(ObjectPrototype);
         ErrorConstructor = new(FunctionPrototype);
         ErrorPrototype.Initialize(this, vm);
@@ -189,6 +191,9 @@ public sealed class Realm
         // 20.1.1 The Object Constructor, https://tc39.es/ecma262/#sec-object-constructor
         globalProperties.Add("Object", new Property(ObjectConstructor, new(true, false, true)));
 
+        // 22.1.1 The String Constructor, https://tc39.es/ecma262/#sec-string-constructor
+        globalProperties.Add("String", new Property(StringConstructor, new(true, false, true)));
+
         return globalProperties;
     }
 
@@ -248,6 +253,7 @@ public sealed class Realm
     internal ObjectPrototype ObjectPrototype { get; private set; }
     internal ObjectConstructor ObjectConstructor { get; private set; }
     internal FunctionPrototype FunctionPrototype { get; private set; }
+    internal StringConstructor StringConstructor { get; private set; }
     internal ErrorPrototype ErrorPrototype { get; private set; }
     internal ErrorConstructor ErrorConstructor { get; private set; }
     internal NativeErrorPrototype EvalErrorPrototype { get; private set; }

--- a/JSS.Lib/Runtime/String.constructor.cs
+++ b/JSS.Lib/Runtime/String.constructor.cs
@@ -1,0 +1,43 @@
+﻿using JSS.Lib.AST.Values;
+using JSS.Lib.Execution;
+
+namespace JSS.Lib.Runtime;
+
+internal class StringConstructor : Object, ICallable, IConstructable
+{
+    // The String constructor has a [[Prototype]] internal slot whose value is %Function.prototype%.
+    public StringConstructor(FunctionPrototype prototype) : base(prototype)
+    {
+    }
+
+    // 22.1.1.1 String ( value ), https://tc39.es/ecma262/#sec-string-constructor-string-value
+    public Completion Call(VM vm, Value thisArgument, List argumentList)
+    {
+        // 1. If value is not present, then
+        string s;
+        if (argumentList.Values.Count == 0)
+        {
+            s = "";
+        }
+        else
+        {
+            // FIXME: a. If NewTarget is undefined and value is a Symbol, return SymbolDescriptiveString(value).
+
+            // b. Let s be ? ToString(value).
+            var value = argumentList.Values[0];
+            var abruptOrS = value.ToStringJS();
+            if (abruptOrS.IsAbruptCompletion()) return abruptOrS.Completion;
+            s = abruptOrS.Value;
+        }
+
+        // NOTE/FIXME: I think this is always true for calls
+        // 3. If NewTarget is undefined, return s.
+        return s; 
+    }
+
+    // 22.1.1.1 String ( value ), https://tc39.es/ecma262/#sec-string-constructor-string-value
+    public Completion Construct(VM vm, List argumentsList)
+    {
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
We now support the String conversion constructor on the global object. This allows for `String` to be called with a value and it returns the passed in value converted to a string.

Example Code:
```js
var s = String(123);
s; // s hold "123"
```