### PR TITLE
JSS-5 Implement the toString function on the Object prototype

### DIFF
--- a/JSS.Lib/Execution/Realm.cs
+++ b/JSS.Lib/Execution/Realm.cs
@@ -53,7 +53,7 @@ public sealed class Realm
         FunctionPrototype = new(ObjectPrototype);
         ObjectConstructor = new(FunctionPrototype);
 
-        ObjectPrototype.Initialize(this);
+        ObjectPrototype.Initialize(this, vm);
         ObjectConstructor.Initialize(this);
 
         StringConstructor = new(FunctionPrototype);

--- a/JSS.Lib/Runtime/Object.prototype.cs
+++ b/JSS.Lib/Runtime/Object.prototype.cs
@@ -11,8 +11,66 @@ internal class ObjectPrototype : Object
     {
     }
 
-    public void Initialize(Realm realm)
+    public void Initialize(Realm realm, VM vm)
     {
+        // 20.1.3.1 Object.prototype.constructor, The initial value of Object.prototype.constructor is %Object%.
         DataProperties.Add("constructor", new Property(realm.ObjectConstructor, new Attributes(true, false, true)));
+
+        // 20.1.3.6 Object.prototype.toString ( ), https://tc39.es/ecma262/#sec-object.prototype.tostring
+        var toStringBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, toString);
+        DataProperties.Add("toString", new Property(toStringBuiltin, new Attributes(true, false, true)));
+    }
+
+    private Completion toString(VM vm, Value? thisValue, List argumentList)
+    {
+        // 1. If the this value is undefined, return "[object Undefined]".
+        if (thisValue is null || thisValue.IsUndefined()) return "[object Undefined]";
+
+        // 2. If the this value is null, return "[object Null]".
+        if (thisValue.IsNull()) return "[object Null]";
+
+        // 3. Let O be ! ToObject(this value).
+        var O = MUST(thisValue.ToObject(vm));
+
+        // FIXME: 4. Let isArray be ? IsArray(O).
+        // FIXME: 5. If isArray is true, let builtinTag be "Array".
+
+        // FIXME: 6. Else if O has a [[ParameterMap]] internal slot, let builtinTag be "Arguments".
+
+        // 7. Else if O has a [[Call]] internal method, let builtinTag be "Function".
+        string builtinTag;
+        if (O.HasInternalCall())
+        {
+            builtinTag = "Function";
+        }
+        // FIXME: 8. Else if O has an [[ErrorData]] internal slot, let builtinTag be "Error".
+        // FIXME: 9. Else if O has a [[BooleanData]] internal slot, let builtinTag be "Boolean".
+        // FIXME: 10. Else if O has a [[NumberData]] internal slot, let builtinTag be "Number".
+        // FIXME: 11. Else if O has a [[StringData]] internal slot, let builtinTag be "String".
+        // FIXME: 12. Else if O has a [[DateValue]] internal slot, let builtinTag be "Date".
+        // FIXME: 13. Else if O has a [[RegExpMatcher]] internal slot, let builtinTag be "RegExp".
+        // 14. Else, let builtinTag be "Object".
+        else
+        {
+            builtinTag = "Object";
+        }
+
+        // 15. Let tag be ? Get(O, @@toStringTag).
+        var getResult = Get(O, "\"Symbol.toStringTag\"");
+        if (getResult.IsAbruptCompletion()) return getResult;
+
+        // 16. If tag is not a String, set tag to builtinTag.
+        string tag;
+        if (!getResult.Value.IsString())
+        {
+            tag = builtinTag;
+        }
+        else
+        {
+            tag = getResult.Value.AsString();
+        }
+
+        // 17. Return the string-concatenation of "[object ", tag, and "]".
+        return "[object " + tag + "]";
     }
 }


### PR DESCRIPTION
This allows for the toString function to be used on objects that inherit from the object prototype.

Example Code:
```js
var obj = {};
obj.toString(); // Returns "[object Object]"
```