### PR TITLE
JSS-6 Implement the call function on the Function prototype

### DIFF
--- a/JSS.Lib/AST/Values/List.cs
+++ b/JSS.Lib/AST/Values/List.cs
@@ -2,6 +2,12 @@
 
 internal sealed class List : Value
 {
+    public List() { }
+    public List(IEnumerable<Value> values)
+    {
+        Values = values.ToList();
+    }
+
     override public ValueType Type() { throw new InvalidOperationException("Tried to get the Type of List"); }
 
     public void Add(Value value) => Values.Add(value);

--- a/JSS.Lib/Execution/Realm.cs
+++ b/JSS.Lib/Execution/Realm.cs
@@ -56,6 +56,8 @@ public sealed class Realm
         ObjectPrototype.Initialize(this, vm);
         ObjectConstructor.Initialize(this);
 
+        FunctionPrototype.Initialize(vm);
+
         StringConstructor = new(FunctionPrototype);
 
         ErrorPrototype = new(ObjectPrototype);

--- a/JSS.Lib/Runtime/Function.prototype.cs
+++ b/JSS.Lib/Runtime/Function.prototype.cs
@@ -1,4 +1,7 @@
-﻿namespace JSS.Lib.Runtime;
+﻿using JSS.Lib.AST.Values;
+using JSS.Lib.Execution;
+
+namespace JSS.Lib.Runtime;
 
 // 20.2.3 Properties of the Function Prototype Object, https://tc39.es/ecma262/#sec-properties-of-the-function-prototype-object
 internal sealed class FunctionPrototype : Object
@@ -6,5 +9,29 @@ internal sealed class FunctionPrototype : Object
     // The Function prototype has a [[Prototype]] internal slot whose value is %Object.prototype%.
     public FunctionPrototype(ObjectPrototype objectPrototype) : base(objectPrototype)
     {
+    }
+
+    public void Initialize(VM vm)
+    {
+        // 20.2.3.3 Function.prototype.call ( thisArg, ...args ), https://tc39.es/ecma262/#sec-function.prototype.call
+        var callBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, call);
+        DataProperties.Add("call", new Property(callBuiltin, new(true, false, true)));
+    }
+
+    // 20.2.3.3 Function.prototype.call ( thisArg, ...args ), https://tc39.es/ecma262/#sec-function.prototype.call
+    private Completion call(VM vm, Value? thisArg, List argumentList)
+    {
+        // 1. Let func be the this value.
+        var func = thisArg;
+
+        // 2. If IsCallable(func) is false, throw a TypeError exception.
+        if (func is null || !func.IsCallable()) return ThrowTypeError(vm, RuntimeErrorType.CallingANonFunction, func?.Type() ?? ValueType.Undefined);
+
+        // FIXME: 3. Perform PrepareForTailCall().
+
+        // 4. Return ? Call(func, thisArg, args).
+        var newThisArg = argumentList[0];
+        var args = new List(argumentList.Values.Skip(1));
+        return Call(vm, func, newThisArg, args);
     }
 }

--- a/JSS.Lib/Runtime/Object.prototype.cs
+++ b/JSS.Lib/Runtime/Object.prototype.cs
@@ -21,6 +21,7 @@ internal class ObjectPrototype : Object
         DataProperties.Add("toString", new Property(toStringBuiltin, new Attributes(true, false, true)));
     }
 
+    // 20.1.3.6 Object.prototype.toString ( ), https://tc39.es/ecma262/#sec-object.prototype.tostring
     private Completion toString(VM vm, Value? thisValue, List argumentList)
     {
         // 1. If the this value is undefined, return "[object Undefined]".


### PR DESCRIPTION
We now implement the call function on the function prototype.

Example Code:
```js
Object.prototype.toString.call({}); // Calls the toString function with {} as the thisValue, returns "[object Object]"
```