### PR TITLE
JSS-8 Change Binding to a reference typed object

### DIFF
--- a/JSS.Lib/Execution/Binding.cs
+++ b/JSS.Lib/Execution/Binding.cs
@@ -2,6 +2,16 @@
 
 namespace JSS.Lib.Execution;
 
-internal record struct Binding(Value Value, bool Mutable, bool Strict)
+internal class Binding
 {
+    public Binding(Value value, bool mutable, bool strict)
+    {
+        Value = value;
+        Mutable = mutable;
+        Strict = strict;
+    }
+
+    public Value Value { get; set; }
+    public bool Mutable { get; }
+    public bool Strict { get; }
 }


### PR DESCRIPTION
We were getting the binding from a dictionary and because Binding was a value type, it would be copied locally. When we changed the value in PutValue, it would only be copied to the local Binding instead of the Binding in the dictionary.

Now, Binding is a reference type so the change is visible to the dictionary.