### PR TITLE
JSS-9 Implement parsing of comma separated var declarations

### DIFF
--- a/JSS.Lib.UnitTests/ParserTests.cs
+++ b/JSS.Lib.UnitTests/ParserTests.cs
@@ -404,8 +404,34 @@ internal sealed class ParserTests
 
         var varStatement = rootNodes[0] as VarStatement;
         varStatement.Should().NotBeNull();
-        varStatement!.Identifier.Should().Be(expectedIdentifier);
-        varStatement!.Initializer.Should().BeNull();
+        varStatement!.Declarations.Should().HaveCount(1);
+
+        var varDeclaration = varStatement.Declarations[0];
+        varDeclaration.Identifier.Should().Be(expectedIdentifier);
+        varDeclaration.Initializer.Should().BeNull();
+    }
+
+    [Test]
+    public void Parse_ReturnsVarStatement_WithMultipleDeclarations_WhenProvidingVarStatement_WithMultipleDeclarations()
+    {
+        // Arrange
+        const string expectedFirstIdentifier = "expectedFirstIdentifier";
+        const string expectedSecondIdentifier = "expectedSecondIdentifier";
+        var parser = new Parser($"var {expectedFirstIdentifier}, {expectedSecondIdentifier}");
+
+        // Act
+        var parsedProgram = ParseScript(parser);
+        var rootNodes = parsedProgram.ScriptCode;
+
+        // Assert
+        rootNodes.Should().HaveCount(1);
+
+        var varStatement = rootNodes[0] as VarStatement;
+        varStatement.Should().NotBeNull();
+        varStatement!.Declarations.Should().HaveCount(2);
+
+        varStatement.Declarations[0].Identifier.Should().Be(expectedFirstIdentifier);
+        varStatement.Declarations[1].Identifier.Should().Be(expectedSecondIdentifier);
     }
 
     [TestCaseSource(nameof(expressionToExpectedTypeTestCases))]
@@ -426,8 +452,11 @@ internal sealed class ParserTests
 
         var varStatement = rootNodes[0] as VarStatement;
         varStatement.Should().NotBeNull();
-        varStatement!.Identifier.Should().Be(expectedIdentifier);
-        varStatement.Initializer.Should().BeOfType(expectedInitializerType);
+        varStatement!.Declarations.Should().HaveCount(1);
+
+        var varDeclaration = varStatement.Declarations[0];
+        varDeclaration.Identifier.Should().Be(expectedIdentifier);
+        varDeclaration.Initializer.Should().BeOfType(expectedInitializerType);
     }
 
     // Tests for 14.4 Empty Statement, https://tc39.es/ecma262/#sec-empty-statement
@@ -602,7 +631,10 @@ internal sealed class ParserTests
 
         var varStatement = forStatement.InitializationExpression as VarStatement;
         varStatement.Should().NotBeNull();
-        varStatement!.Identifier.Should().Be(expectedIdentifier);
+        varStatement!.Declarations.Should().HaveCount(1);
+
+        var varDeclaration = varStatement.Declarations[0];
+        varDeclaration.Identifier.Should().Be(expectedIdentifier);
     }
 
     [Test]
@@ -1636,6 +1668,7 @@ internal sealed class ParserTests
         {"super.", "}"},
         {"let", "}"},
         {"let a = ", "}"},
+        {"var a,", "}" },
         {"for (1 ", "1"},
         {"for (1; 1 ", "1"},
         {"for (1; 1; 1 ", "1"},
@@ -1744,6 +1777,7 @@ internal sealed class ParserTests
         "let",
         "let a = ",
         "let a = {",
+        "var a,",
         "for (1 ",
         "for (1; 1 ",
         "for (1; 1; 1 ",

--- a/JSS.Lib/AST/VarDeclaration.cs
+++ b/JSS.Lib/AST/VarDeclaration.cs
@@ -1,0 +1,80 @@
+﻿using JSS.Lib.Execution;
+using JSS.Lib.AST.Values;
+
+namespace JSS.Lib.AST;
+
+// 14.3.2 Variable Statement, https://tc39.es/ecma262/#sec-variable-statement
+internal sealed class VarDeclaration : INode
+{
+    public VarDeclaration(string identifier, INode? initializer)
+    {
+        Identifier = identifier;
+        Initializer = initializer;
+    }
+
+    // 8.2.1 Static Semantics: BoundNames, https://tc39.es/ecma262/#sec-static-semantics-boundnames
+    override public List<string> BoundNames()
+    {
+        // 1. Return a List whose sole element is the StringValue of Identifier.
+        return new List<string> { Identifier };
+    }
+
+    // 8.2.7 Static Semantics: VarScopedDeclarations, https://tc39.es/ecma262/#sec-static-semantics-varscopeddeclarations
+    override public List<INode> VarScopedDeclarations()
+    {
+        // 1. Return « VariableDeclaration ».
+        return new List<INode> { this };
+    }
+
+    // 14.3.2.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-variable-statement-runtime-semantics-evaluation
+    override public Completion Evaluate(VM vm)
+    {
+        if (Initializer is null)
+        {
+            return EvaluateWithoutInitializer();
+        }
+        else
+        {
+            return EvaluateWithInitializer(vm);
+        }
+    }
+
+    private Completion EvaluateWithoutInitializer()
+    {
+        // 1. Return EMPTY.
+        return Empty.The;
+    }
+
+    private Completion EvaluateWithInitializer(VM vm)
+    {
+        // 1. Let bindingId be StringValue of BindingIdentifier.
+        var bindingId = Identifier;
+
+        // 2. Let lhs be ? ResolveBinding(bindingId).
+        var lhs = ScriptExecutionContext.ResolveBinding(vm, bindingId);
+        if (lhs.IsAbruptCompletion()) return lhs;
+
+        // FIXME: 3. If IsAnonymousFunctionDefinition(Initializer) is true, then
+        // FIXME: a. Let value be ? NamedEvaluation of Initializer with argument bindingId.
+
+        // 4. Else,
+        // a. Let rhs be ? Evaluation of Initializer.
+        var rhs = Initializer!.Evaluate(vm);
+        if (rhs.IsAbruptCompletion()) return rhs;
+
+        // b. Let value be ? GetValue(rhs).
+        var value = rhs.Value.GetValue(vm);
+        if (value.IsAbruptCompletion()) return value;
+
+        // 5. Perform ? PutValue(lhs, value).
+        var putResult = lhs.Value.PutValue(vm, value.Value);
+        if (putResult.IsAbruptCompletion()) return putResult;
+
+        // 6. Return EMPTY.
+        return Empty.The;
+    }
+
+    public string Identifier { get; }
+
+    public INode? Initializer { get; }
+}

--- a/JSS.Lib/AST/VarStatement.cs
+++ b/JSS.Lib/AST/VarStatement.cs
@@ -1,22 +1,28 @@
-﻿using JSS.Lib.Execution;
-using JSS.Lib.AST.Values;
+﻿using JSS.Lib.AST.Values;
+using JSS.Lib.Execution;
 
 namespace JSS.Lib.AST;
 
-// 14.3.2 Variable Statement, https://tc39.es/ecma262/#sec-variable-statement
 internal sealed class VarStatement : INode
 {
-    public VarStatement(string identifier, INode? initializer)
+    public VarStatement(List<VarDeclaration> declarations)
     {
-        Identifier = identifier;
-        Initializer = initializer;
+        Declarations = declarations;
     }
 
     // 8.2.1 Static Semantics: BoundNames, https://tc39.es/ecma262/#sec-static-semantics-boundnames
     override public List<string> BoundNames()
     {
-        // 1. Return the BoundNames of BindingIdentifier.
-        return new List<string> { Identifier };
+        // 1. Let names1 be BoundNames of VariableDeclarationList.
+        // 2. Let names2 be BoundNames of VariableDeclaration.
+        List<string> boundNames = new();
+        foreach (var declaration in Declarations)
+        {
+            boundNames.AddRange(declaration.BoundNames());
+        }
+
+        // 3. Return the list-concatenation of names1 and names2.
+        return boundNames;
     }
 
     // 8.2.6 Static Semantics: VarDeclaredNames, https://tc39.es/ecma262/#sec-static-semantics-vardeclarednames
@@ -29,59 +35,24 @@ internal sealed class VarStatement : INode
     // 8.2.7 Static Semantics: VarScopedDeclarations, https://tc39.es/ecma262/#sec-static-semantics-varscopeddeclarations
     override public List<INode> VarScopedDeclarations()
     {
-        // 1. Return « VariableDeclaration ».
-        return new List<INode> { this };
+        // 1. Let declarations1 be VarScopedDeclarations of VariableDeclarationList.
+        // 2. Return the list-concatenation of declarations1 and « VariableDeclaration ».
+        return new(Declarations);
     }
 
     // 14.3.2.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-variable-statement-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
-        if (Initializer is null)
+        // 1. Perform ? Evaluation of VariableDeclarationList.
+        foreach (var declaration in Declarations)
         {
-            return EvaluateWithoutInitializer();
+            var result = declaration.Evaluate(vm);
+            if (result.IsAbruptCompletion()) return result;
         }
-        else
-        {
-            return EvaluateWithInitializer(vm);
-        }
-    }
 
-    private Completion EvaluateWithoutInitializer()
-    {
-        // 1. Return EMPTY.
+        // 2. Return EMPTY.
         return Empty.The;
     }
 
-    private Completion EvaluateWithInitializer(VM vm)
-    {
-        // 1. Let bindingId be StringValue of BindingIdentifier.
-        var bindingId = Identifier;
-
-        // 2. Let lhs be ? ResolveBinding(bindingId).
-        var lhs = ScriptExecutionContext.ResolveBinding(vm, bindingId);
-        if (lhs.IsAbruptCompletion()) return lhs;
-
-        // FIXME: 3. If IsAnonymousFunctionDefinition(Initializer) is true, then
-        // FIXME: a. Let value be ? NamedEvaluation of Initializer with argument bindingId.
-
-        // 4. Else,
-        // a. Let rhs be ? Evaluation of Initializer.
-        var rhs = Initializer!.Evaluate(vm);
-        if (rhs.IsAbruptCompletion()) return rhs;
-
-        // b. Let value be ? GetValue(rhs).
-        var value = rhs.Value.GetValue(vm);
-        if (value.IsAbruptCompletion()) return value;
-
-        // 5. Perform ? PutValue(lhs, value).
-        var putResult = lhs.Value.PutValue(vm, value.Value);
-        if (putResult.IsAbruptCompletion()) return putResult;
-
-        // 6. Return EMPTY.
-        return Empty.The;
-    }
-
-    public string Identifier { get; }
-
-    public INode? Initializer { get; }
+    public IReadOnlyList<VarDeclaration> Declarations { get; }
 }

--- a/JSS.Lib/Execution/Script.cs
+++ b/JSS.Lib/Execution/Script.cs
@@ -121,7 +121,7 @@ public sealed class Script
             var d = varDeclarations[i];
 
             // a. If d is not either a VariableDeclaration, a ForBinding, or a BindingIdentifier, then
-            if (d is not VarStatement or Identifier)
+            if (d is not VarDeclaration or Identifier)
             {
                 // i. Assert: d is either a FunctionDeclaration, FIXME: a GeneratorDeclaration, an AsyncFunctionDeclaration, or an AsyncGeneratorDeclaration.
                 Debug.Assert(d is FunctionDeclaration);
@@ -158,7 +158,7 @@ public sealed class Script
         foreach (var d in varDeclarations)
         {
             // a. If d is either a VariableDeclaration, a ForBinding, or a BindingIdentifier, then
-            if (d is VarStatement or Identifier)
+            if (d is VarDeclaration or Identifier)
             {
                 // i. For each String vn of the BoundNames of d, do
                 foreach (var vn in d.BoundNames())

--- a/JSS.Lib/Parser.cs
+++ b/JSS.Lib/Parser.cs
@@ -1451,17 +1451,44 @@ public sealed class Parser
     {
         _consumer.ConsumeTokenOfType(TokenType.Var);
 
+        var declarationList = ParseVarDeclarationList();
+
+        return new VarStatement(declarationList);
+    }
+
+    private List<VarDeclaration> ParseVarDeclarationList()
+    {
+        List<VarDeclaration> declarationList = new();
+
+        while (true)
+        {
+            var declaration = ParseVarDeclaration();
+            declarationList.Add(declaration);
+
+            // We want to keep parsing declarations every time there is a comma
+            if (!_consumer.IsTokenOfType(TokenType.Comma))
+            {
+                break;
+            }
+
+            _consumer.ConsumeTokenOfType(TokenType.Comma);
+        }
+
+        return declarationList;
+    }
+
+    private VarDeclaration ParseVarDeclaration()
+    {
         // FIXME: Allow let/await/yield to be used as an indentifier when specified in the spec
         var identifierToken = _consumer.ConsumeTokenOfType(TokenType.Identifier);
 
-        // FIXME: We should allow parsing multiple bindings in a single var statement 
         INode? initializer = null;
         if (IsInitializer())
         {
             initializer = ParseInitializer();
         }
 
-        return new VarStatement(identifierToken.data, initializer);
+        return new(identifierToken.data, initializer);
     }
 
     private bool IsInitializer()


### PR DESCRIPTION
We now support comma seperated var declarations. This allows for more than one var declaration to be declared on a single statement.

Example Code:
```js
var a, b;
a; // Holds undefined
b; // Holds undefined
c; // Throws ReferenceError
```