### PR TITLE
JSS-10 Check for VarDeclarations in FunctionDeclarationInstantiation

### DIFF
--- a/JSS.Lib/AST/Values/FunctionObject.cs
+++ b/JSS.Lib/AST/Values/FunctionObject.cs
@@ -420,7 +420,7 @@ internal sealed class FunctionObject : Object, ICallable, IConstructable
             var d = varDeclarations[i];
 
             // a. If d is neither a VariableDeclaration nor a ForBinding nor a BindingIdentifier, then
-            if (d is not Identifier)
+            if (d is not VarDeclaration or Identifier)
             {
                 // i. Assert: d is either a FunctionDeclaration, a GeneratorDeclaration, an AsyncFunctionDeclaration, or an AsyncGeneratorDeclaration.
                 Debug.Assert(d is FunctionDeclaration);


### PR DESCRIPTION
Inside of FunctionDeclarationInstantiation we didn't properly check for a VarDeclaration that the spec was expecting, so we hit an assert from the spec.