### PR TITLE
Handle throw completions properly when calling ArgumentListEvaluation

### DIFF
--- a/JSS.Lib/AST/CallExpression.cs
+++ b/JSS.Lib/AST/CallExpression.cs
@@ -86,6 +86,7 @@ internal sealed class CallExpression : IExpression
         // FIXME: Make a ArgumentList class
         // 3. Let argList be ? ArgumentListEvaluation of arguments.
         var argList = ArgumentListEvaluation(vm);
+        if (argList.IsAbruptCompletion()) return argList;
 
         // 4. If func is not an Object, throw a TypeError exception.
         if (!func.IsObject())

--- a/JSS.Lib/AST/CallExpression.cs
+++ b/JSS.Lib/AST/CallExpression.cs
@@ -86,7 +86,7 @@ internal sealed class CallExpression : IExpression
         // FIXME: Make a ArgumentList class
         // 3. Let argList be ? ArgumentListEvaluation of arguments.
         var argList = ArgumentListEvaluation(vm);
-        if (argList.IsAbruptCompletion()) return argList;
+        if (argList.IsAbruptCompletion()) return argList.Completion;
 
         // 4. If func is not an Object, throw a TypeError exception.
         if (!func.IsObject())
@@ -107,7 +107,7 @@ internal sealed class CallExpression : IExpression
     }
 
     // 13.3.8.1 Runtime Semantics: ArgumentListEvaluation, https://tc39.es/ecma262/#sec-runtime-semantics-argumentlistevaluation
-    private Completion ArgumentListEvaluation(VM vm)
+    private AbruptOr<List> ArgumentListEvaluation(VM vm)
     {
         // 1. Let precedingArgs be ? ArgumentListEvaluation of ArgumentList.
         List precedingArgs = new();

--- a/JSS.Lib/AST/Values/Object.cs
+++ b/JSS.Lib/AST/Values/Object.cs
@@ -105,7 +105,7 @@ public class Object : Value
     }
 
     // 7.3.14 Call ( F, V [ , argumentsList ] )
-    static internal Completion Call(VM vm, Value F, Value V, Value? argumentsList = null)
+    static internal Completion Call(VM vm, Value F, Value V, List? argumentsList = null)
     {
         // 1. If argumentsList is not present, set argumentsList to a new empty List.
         argumentsList ??= new List();
@@ -118,7 +118,7 @@ public class Object : Value
 
         // 3. Return ? F.[[Call]](V, argumentsList).
         var asCallable = F.AsCallable(); 
-        return asCallable.Call(vm, V, (argumentsList as List)!);
+        return asCallable.Call(vm, V, argumentsList);
     }
 
     // 10.1.1 [[GetPrototypeOf]] ( ), https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof


### PR DESCRIPTION
We now check if ArgumentListEvaluation returns a throw completion, instead of always assuming it would return a normal completion.

This could happen if a function was called with some arguments and those arguments would somehow cause a throw.

Example Code:
```js
function test(param) {}
test(falsE); // Now throws a ReferenceError instead of crashing
```