### PR TITLE
JSS-12 Support undefined with ToStringJS

### DIFF
--- a/JSS.Lib/AST/Values/Value.cs
+++ b/JSS.Lib/AST/Values/Value.cs
@@ -378,7 +378,8 @@ public abstract class Value
 
         // FIXME: 2. If argument is a Symbol, throw a TypeError exception.
 
-        // FIXME: 3. If argument is undefined, return "undefined".
+        // 3. If argument is undefined, return "undefined".
+        if (IsUndefined()) return "undefined";
 
         // 4. If argument is null, return "null".
         if (IsNull()) return "null";


### PR DESCRIPTION
We now support undefined with ToStringJS.

This also allows string concatenation with undefined to work now.

Example Code:
```js
var e = "" + undefined; // Holds "undefined", would crash before
```