### PR TITLE
JSS-13 Support strict (in)equality of Objects using their identity

### DIFF
--- a/JSS.Lib/AST/Values/Value.cs
+++ b/JSS.Lib/AST/Values/Value.cs
@@ -506,9 +506,10 @@ public abstract class Value
             return xAsBoolean == yAsBoolean;
         }
 
-        // FIXME: 6. NOTE: All other ECMAScript language values are compared by identity.
-        // FIXME: 7. If x is y, return true; otherwise, return false.
-        throw new NotImplementedException();
+        // NOTE: x and y should be reference types, comparing values by identity is the same as the reference equality between the two values
+        // 6. NOTE: All other ECMAScript language values are compared by identity.
+        // 7. If x is y, return true; otherwise, return false.
+        return ReferenceEquals(x, y);
     }
 
     // 7.2.13 IsLessThan ( x, y, LeftFirst ), https://tc39.es/ecma262/#sec-islessthan


### PR DESCRIPTION
We now support strict (in)equality of two Objects. If they have the same reference in C# that means they have the same "identity". There might be edge cases in spec that we don't know about, but for now C# reference equality is the same as identity equality.

Example Code:
```js
var a = {};
var b = {};
var c = a;
a === b; // Returns false, used to crash
a === b; // Returns true, used to crash
```