### PR TITLE
JSS-14 Support the basics of the arguments object

### DIFF
--- a/JSS.Lib/AST/Values/FunctionObject.cs
+++ b/JSS.Lib/AST/Values/FunctionObject.cs
@@ -658,6 +658,27 @@ internal sealed class FunctionObject : Object, ICallable, IConstructable
         return names;
     }
 
+    // FIXME: Have a seperate arguments object class to support the all of the arguments functionality
+    // 10.4.4.7 CreateMappedArgumentsObject ( func, formals, argumentsList, env ), https://tc39.es/ecma262/#sec-createmappedargumentsobject
+    private Object CreateMappedArgumentsObject(VM vm, List argumentsList, Environment _)
+    {
+        // FIXME: Other steps are ommited due to brevity, but need to be implemented
+
+        // 2. Let len be the number of elements in argumentsList.
+        var len = argumentsList.Count;
+
+        // FIXME: 3. Let obj be MakeBasicObject(« [[Prototype]], [[Extensible]], [[ParameterMap]] »).
+        // 9. Set obj.[[Prototype]] to %Object.prototype%.
+        var obj = new Object(vm.ObjectPrototype);
+
+        // 16. Perform ! DefinePropertyOrThrow(obj, "length", PropertyDescriptor { [[Value]]: 𝔽(len), [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }).
+        MUST(DefinePropertyOrThrow(vm, obj, "length", new(len, new(true, false, true))));
+
+        // 22. Return obj.
+        return obj;
+    }
+
+
     public IReadOnlyList<Identifier> FormalParameters { get; private set; }
     public StatementList ECMAScriptCode { get; private set; }
     public Environment Environment { get; private set; }

--- a/JSS.Lib/AST/Values/List.cs
+++ b/JSS.Lib/AST/Values/List.cs
@@ -13,6 +13,8 @@ internal sealed class List : Value
     public void Add(Value value) => Values.Add(value);
     public void ListConcatenation(List list) => Values.AddRange(list.Values);
 
+    public int Count => Values.Count;
+
     public Value this[int i]
     {
         get


### PR DESCRIPTION
We now support the basics of the argument objects.

We can now use arguments.length to determine how many arguments were
passed to a function.

Example Code:
```js
function test(a, b)
{
    return arguments.length;
}

test(); // Returns 0
test(1, 2); // Returns 2
```