### PR TITLE
JSS-16 Implement support for arrays as needed in propertyHelper.js for test-262

### DIFF
--- a/JSS.Lib.UnitTests/ParserTests.cs
+++ b/JSS.Lib.UnitTests/ParserTests.cs
@@ -1591,6 +1591,31 @@ internal sealed class ParserTests
         assignmentExpression.Rhs.Should().BeOfType(expectedExpressionType);
     }
 
+    // FIXME: More tests when we don't only parse empty array literals
+    // Tests for ArrayLiteral
+    [Test]
+    public void Parse_ReturnsAssignment_WithArrayLiteralRHS_WhenProvidingAssignment_WithArrayLiteralRHS()
+    {
+        // Arrange
+        var parser = new Parser("a = []");
+
+        // Act
+        var parsedProgram = ParseScript(parser);
+        var rootNodes = parsedProgram.ScriptCode;
+
+        // Assert
+        rootNodes.Should().HaveCount(1);
+
+        var expressionStatement = rootNodes[0] as ExpressionStatement;
+        expressionStatement.Should().NotBeNull();
+
+        var assignmentExpression = expressionStatement!.Expression as BasicAssignmentExpression;
+        assignmentExpression.Should().NotBeNull();
+
+        var objectLiteral = assignmentExpression!.Rhs as ArrayLiteral;
+        objectLiteral.Should().NotBeNull();
+    }
+
     // FIXME: More tests when we don't only parse empty object literals
     // Tests for ObjectLiteral
     [Test]

--- a/JSS.Lib/AST/Literal/ArrayLiteral.cs
+++ b/JSS.Lib/AST/Literal/ArrayLiteral.cs
@@ -1,0 +1,5 @@
+﻿namespace JSS.Lib.AST.Literal;
+
+internal sealed class ArrayLiteral : IExpression
+{
+}

--- a/JSS.Lib/AST/Literal/ArrayLiteral.cs
+++ b/JSS.Lib/AST/Literal/ArrayLiteral.cs
@@ -1,5 +1,17 @@
-﻿namespace JSS.Lib.AST.Literal;
+﻿using JSS.Lib.Execution;
+
+namespace JSS.Lib.AST.Literal;
 
 internal sealed class ArrayLiteral : IExpression
 {
+    // 13.2.4.2 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-array-initializer-runtime-semantics-evaluation
+    override public Completion Evaluate(VM vm)
+    {
+        // FIXME: Implement the rest of the evaluation when we parse element lists
+        // 1. Let array be ! ArrayCreate(0).
+        var array = MUST(Array.ArrayCreate(0));
+
+        // 3. Return array.
+        return array;
+    }
 }

--- a/JSS.Lib/AST/Values/Array.cs
+++ b/JSS.Lib/AST/Values/Array.cs
@@ -1,0 +1,29 @@
+﻿using JSS.Lib.Execution;
+
+namespace JSS.Lib.AST.Values;
+
+// 10.4.2 Array Exotic Objects, https://tc39.es/ecma262/#sec-array-exotic-objects
+internal sealed class Array : Object
+{
+    public Array(Object? prototype) : base(prototype)
+    {
+    }
+
+    // 10.4.2.2 ArrayCreate ( length [ , proto ] )
+    static public AbruptOr<Array> ArrayCreate(int length, Object? prototype = null)
+    {
+        // FIXME: 1. If length > 2**32 - 1, throw a RangeError exception.
+        // FIXME: 2. If proto is not present, set proto to %Array.prototype%.
+
+        // 3. Let A be MakeBasicObject(« [[Prototype]], [[Extensible]] »).
+        // 4. Set A.[[Prototype]] to proto.
+        // FIXME: 5. Set A.[[DefineOwnProperty]] as specified in 10.4.2.1.
+        var A = new Array(prototype);
+
+        // 6. Perform ! OrdinaryDefineOwnProperty(A, "length", PropertyDescriptor { [[Value]]: 𝔽(length), [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: false }).
+        MUST(OrdinaryDefineOwnProperty(A, "length", new Property(length, new(true, false, false))));
+
+        // 7. Return A.
+        return A;
+    }
+}

--- a/JSS.Lib/AST/Values/Array.cs
+++ b/JSS.Lib/AST/Values/Array.cs
@@ -1,4 +1,5 @@
 ﻿using JSS.Lib.Execution;
+using System.Diagnostics;
 
 namespace JSS.Lib.AST.Values;
 
@@ -25,5 +26,61 @@ internal sealed class Array : Object
 
         // 7. Return A.
         return A;
+    }
+
+    // 10.4.2.4 ArraySetLength ( A, Desc ), https://tc39.es/ecma262/#sec-arraysetlength
+    private Completion ArraySetLength(Property desc)
+    {
+        // FIXME: 1. If Desc does not have a [[Value]] field, then
+        // FIXME: a. Return ! OrdinaryDefineOwnProperty(A, "length", Desc).
+
+        // 2. Let newLenDesc be a copy of Desc.
+        var newLenDesc = desc.Copy();
+
+        // 3. Let newLen be ? ToUint32(Desc.[[Value]]).
+        var newLen = desc.Value.ToUint32();
+        if (newLen.IsAbruptCompletion()) return newLen.Completion;
+
+        // FIXME: 4. Let numberLen be ? ToNumber(Desc.[[Value]]).
+        // FIXME: 5. If SameValueZero(newLen, numberLen) is false, throw a RangeError exception.
+
+        // 6. Set newLenDesc.[[Value]] to newLen.
+        newLenDesc.Value = newLen.Value;
+
+        // 7. Let oldLenDesc be OrdinaryGetOwnProperty(A, "length").
+        // FIXME: OrdinaryGetOwnProperty shouldn't return a completion
+        var oldLenDesc = OrdinaryGetOwnProperty(this, "length").Value.AsProperty();
+
+        // FIXME: 8. Assert: IsDataDescriptor(oldLenDesc) is true.
+        // 9. Assert: oldLenDesc.[[Configurable]] is false.
+        Debug.Assert(!oldLenDesc.Attributes.Configurable);
+
+        // 10. Let oldLen be oldLenDesc.[[Value]].
+        var oldLen = oldLenDesc.Value.AsNumber();
+
+        // FIXME: 11. If newLen ≥ oldLen, then
+        // a. Return ! OrdinaryDefineOwnProperty(A, "length", newLenDesc).
+        return MUST(OrdinaryDefineOwnProperty(this, "length", newLenDesc));
+
+        // FIXME: 12. If oldLenDesc.[[Writable]] is false, return false.
+        // FIXME: 13. If (newLenDesc does not have a [[Writable]] field) or newLenDesc.[[Writable]] is true, then
+        // FIXME: a. Let newWritable be true.
+        // FIXME: 14. Else,
+        // FIXME: a. NOTE: Setting the [[Writable]] attribute to false is deferred in case any elements cannot be deleted.
+        // FIXME: b. Let newWritable be false.
+        // FIXME: c. Set newLenDesc.[[Writable]] to true.
+        // FIXME: 15. Let succeeded be ! OrdinaryDefineOwnProperty(A, "length", newLenDesc).
+        // FIXME: 16. If succeeded is false, return false.
+        // FIXME: 17. For each own property key P of A such that P is an array index and ! ToUint32(P) ≥ newLen, in descending numeric index order, do
+        // FIXME: a. Let deleteSucceeded be ! A.[[Delete]](P).
+        // FIXME: b. If deleteSucceeded is false, then
+        // FIXME: i. Set newLenDesc.[[Value]] to ! ToUint32(P) + 1𝔽.
+        // FIXME: ii. If newWritable is false, set newLenDesc.[[Writable]] to false.
+        // FIXME: iii. Perform ! OrdinaryDefineOwnProperty(A, "length", newLenDesc).
+        // FIXME: iv. Return false.
+        // FIXME: 18. If newWritable is false, then
+        // FIXME: a. Set succeeded to ! OrdinaryDefineOwnProperty(A, "length", PropertyDescriptor { [[Writable]]: false }).
+        // FIXME: b. Assert: succeeded is true.
+        // FIXME: 19. Return true.
     }
 }

--- a/JSS.Lib/AST/Values/List.cs
+++ b/JSS.Lib/AST/Values/List.cs
@@ -1,4 +1,6 @@
-﻿namespace JSS.Lib.AST.Values;
+﻿using JSS.Lib.Execution;
+
+namespace JSS.Lib.AST.Values;
 
 internal sealed class List : Value
 {
@@ -12,6 +14,31 @@ internal sealed class List : Value
 
     public void Add(Value value) => Values.Add(value);
     public void ListConcatenation(List list) => Values.AddRange(list.Values);
+
+
+    // 7.3.17 CreateArrayFromList ( elements ), https://tc39.es/ecma262/#sec-createarrayfromlist
+    public Array CreateArrayFromList(VM vm)
+    {
+        // 1. Let array be ! ArrayCreate(0).
+        var array = MUST(Array.ArrayCreate(0));
+
+        // 2. Let n be 0.
+        var n = 0;
+
+        // 3. For each element e of elements, do
+        foreach (var e in Values)
+        {
+            // FIXME: We don't call ToString on n and we just use C#'s ToString
+            // a. Perform ! CreateDataPropertyOrThrow(array, ! ToString(𝔽(n)), e).
+            MUST(Object.CreateDataPropertyOrThrow(vm, array, n.ToString(), e));
+
+            // b. Set n to n + 1.
+            n += 1;
+        }
+
+        // 4. Return array.
+        return array;
+    }
 
     public int Count => Values.Count;
 

--- a/JSS.Lib/AST/Values/Object.cs
+++ b/JSS.Lib/AST/Values/Object.cs
@@ -167,7 +167,7 @@ public class Object : Value
     }
 
     // 10.1.5.1 OrdinaryGetOwnProperty ( O, P ), https://tc39.es/ecma262/#sec-ordinarygetownproperty
-    private Completion OrdinaryGetOwnProperty(Object O, string P)
+    protected Completion OrdinaryGetOwnProperty(Object O, string P)
     {
         // 1. If O does not have an own property with key P, return undefined.
         if (!O.DataProperties.ContainsKey(P))

--- a/JSS.Lib/AST/Values/Object.cs
+++ b/JSS.Lib/AST/Values/Object.cs
@@ -203,7 +203,15 @@ public class Object : Value
         // FIXME: 1. Let current be ? O.[[GetOwnProperty]](P).
         // FIXME: 2. Let extensible be ? IsExtensible(O).
         // FIXME: 3. Return ValidateAndApplyPropertyDescriptor(O, P, extensible, Desc, current).
-        O.DataProperties.Add(P, desc);
+        if (O.DataProperties.ContainsKey(P))
+        {
+            O.DataProperties[P] = desc;
+        }
+        else
+        {
+            O.DataProperties.Add(P, desc);
+        }
+
         return true;
     }
 

--- a/JSS.Lib/AST/Values/Object.cs
+++ b/JSS.Lib/AST/Values/Object.cs
@@ -191,7 +191,7 @@ public class Object : Value
     }
 
     // 10.1.6 [[DefineOwnProperty]] ( P, Desc ), https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc
-    internal Completion DefineOwnProperty(string P, Property desc)
+    virtual internal Completion DefineOwnProperty(string P, Property desc)
     {
         // 1. Return ? OrdinaryDefineOwnProperty(O, P, Desc).
         return OrdinaryDefineOwnProperty(this, P, desc);

--- a/JSS.Lib/AST/Values/Object.cs
+++ b/JSS.Lib/AST/Values/Object.cs
@@ -299,6 +299,35 @@ public class Object : Value
         return true;
     }
 
+    // 10.1.11 [[OwnPropertyKeys]] ( ), https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys
+    internal List OwnPropertyKeys()
+    {
+        // 1. Return OrdinaryOwnPropertyKeys(O).
+        return OrdinaryOwnPropertyKeys(this);
+    }
+
+    // 10.1.11.1 OrdinaryOwnPropertyKeys ( O ), https://tc39.es/ecma262/#sec-ordinaryownpropertykeys
+    static internal List OrdinaryOwnPropertyKeys(Object O)
+    {
+        // 1. Let keys be a new empty List.
+        var keys = new List();
+
+        // FIXME: 2. For each own property key P of O such that P is an array index, in ascending numeric index order, do
+        // FIXME: a. Append P to keys.
+        // FIXME: 3. For each own property key P of O such that P is a String and P is not an array index, in ascending chronological order of property creation, do
+        // FIXME: a. Append P to keys.
+        // FIXME: 4. For each own property key P of O such that P is a Symbol, in ascending chronological order of property creation, do
+        // FIXME: a. Append P to keys.
+
+        foreach (var (P, _)  in O.DataProperties)
+        {
+            keys.Add(P);
+        }
+
+        // 5. Return keys.
+        return keys;
+    }
+
     // FIXME: Accessor Attributes
     internal Object? Prototype { get; }
     internal Dictionary<string, Property> DataProperties { get; }

--- a/JSS.Lib/AST/Values/Object.cs
+++ b/JSS.Lib/AST/Values/Object.cs
@@ -300,7 +300,7 @@ public class Object : Value
     }
 
     // 10.1.11 [[OwnPropertyKeys]] ( ), https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys
-    internal List OwnPropertyKeys()
+    internal AbruptOr<List> OwnPropertyKeys()
     {
         // 1. Return OrdinaryOwnPropertyKeys(O).
         return OrdinaryOwnPropertyKeys(this);

--- a/JSS.Lib/AST/Values/Property.cs
+++ b/JSS.Lib/AST/Values/Property.cs
@@ -16,6 +16,11 @@ internal sealed class Property : Value
     override public bool IsProperty() { return true; }
     override public ValueType Type() { throw new InvalidOperationException("Tried to get the Type of Property"); }
 
+    public Property Copy()
+    {
+        return (MemberwiseClone() as Property)!;
+    }
+
     public Value Value { get; set; }
     public Attributes Attributes { get; }
 }

--- a/JSS.Lib/Parser.cs
+++ b/JSS.Lib/Parser.cs
@@ -1252,6 +1252,11 @@ public sealed class Parser
             parsedExpression = ParseStringLiteral();
             return true;
         }
+        if (IsArrayLiteral())
+        {
+            parsedExpression = ParseArrayLiteral();
+            return true;
+        }
         if (IsObjectLiteral())
         {
             parsedExpression = ParseObjectLiteral();
@@ -1363,6 +1368,21 @@ public sealed class Parser
         var stringLiteral = _consumer.ConsumeTokenOfType(TokenType.String);
         var stringValue = stringLiteral.data[1..^1];
         return new StringLiteral(stringValue);
+    }
+
+    // 13.2.4 Array Initializer, https://tc39.es/ecma262/#sec-array-initializer
+    private bool IsArrayLiteral()
+    {
+        return _consumer.IsTokenOfType(TokenType.OpenSquare);
+    }
+
+    private ArrayLiteral ParseArrayLiteral()
+    {
+        // FIXME: Implement parsing of ElementList
+        _consumer.ConsumeTokenOfType(TokenType.OpenSquare);
+        _consumer.ConsumeTokenOfType(TokenType.ClosedSquare);
+
+        return new ArrayLiteral();
     }
 
     // 13.2.5 Object Initializer, https://tc39.es/ecma262/#prod-ObjectLiteral

--- a/JSS.Lib/Runtime/Object.constructor.cs
+++ b/JSS.Lib/Runtime/Object.constructor.cs
@@ -68,4 +68,30 @@ internal class ObjectConstructor : Object, ICallable, IConstructable
         // 4. Return FromPropertyDescriptor(desc).
         return desc.Value.FromPropertyDescriptor(vm);
     }
+
+    // 20.1.2.11.1 GetOwnPropertyKeys ( O, FIXME: type ), https://tc39.es/ecma262/#sec-getownpropertykeys
+    private AbruptOr<List> GetOwnPropertyKeys(VM vm, Value? _, List argumentList)
+    {
+        // 1. Let obj be ? ToObject(O).
+        var obj = argumentList[0].ToObject(vm);
+        if (obj.IsAbruptCompletion()) return obj.Completion;
+
+        // 2. Let keys be ? obj.[[OwnPropertyKeys]]().
+        var keys = obj.Value.OwnPropertyKeys();
+        if (keys.IsAbruptCompletion()) return keys;
+
+        // 3. Let nameList be a new empty List.
+        var nameList = new List();
+
+        // 4. For each element nextKey of keys, do
+        foreach (var nextKey in keys.Value.Values)
+        {
+            // FIXME: a. If nextKey is a Symbol and type is SYMBOL, or if nextKey is a String and type is STRING, then
+            // i. Append nextKey to nameList.
+            nameList.Add(nextKey);
+        }
+
+        // 5. Return nameList.
+        return nameList;
+    }
 }

--- a/JSS.Lib/Runtime/Object.constructor.cs
+++ b/JSS.Lib/Runtime/Object.constructor.cs
@@ -24,6 +24,10 @@ internal class ObjectConstructor : Object, ICallable, IConstructable
         // 20.1.2.8 Object.getOwnPropertyDescriptor ( O, P ), https://tc39.es/ecma262/#sec-object.getownpropertydescriptor
         var getOwnPropertyDescriptorBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, getOwnPropertyDescriptor);
         DataProperties.Add("getOwnPropertyDescriptor", new Property(getOwnPropertyDescriptorBuiltin, new(true, false, true)));
+
+        // 20.1.2.10 Object.getOwnPropertyNames ( O ), https://tc39.es/ecma262/#sec-object.getownpropertynames
+        var getOwnPropertyNamesBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, getOwnPropertyNames);
+        DataProperties.Add("getOwnPropertyNames", new Property(getOwnPropertyNamesBuiltin, new(true, false, true)));
     }
 
     // 20.1.1.1 Object ( [ value ] ), https://tc39.es/ecma262/#sec-object-value
@@ -69,11 +73,20 @@ internal class ObjectConstructor : Object, ICallable, IConstructable
         return desc.Value.FromPropertyDescriptor(vm);
     }
 
+    // 20.1.2.10 Object.getOwnPropertyNames ( O ), https://tc39.es/ecma262/#sec-object.getownpropertynames
+    private Completion getOwnPropertyNames(VM vm, Value? thisArgument, List argumentList)
+    {
+        // 1. Return CreateArrayFromList(? GetOwnPropertyKeys(O, STRING)).
+        var ownPropertyKeys = GetOwnPropertyKeys(vm, argumentList[0]);
+        if (ownPropertyKeys.IsAbruptCompletion()) return ownPropertyKeys.Completion;
+        return ownPropertyKeys.Value.CreateArrayFromList(vm);
+    }
+
     // 20.1.2.11.1 GetOwnPropertyKeys ( O, FIXME: type ), https://tc39.es/ecma262/#sec-getownpropertykeys
-    private AbruptOr<List> GetOwnPropertyKeys(VM vm, Value? _, List argumentList)
+    private AbruptOr<List> GetOwnPropertyKeys(VM vm, Value O)
     {
         // 1. Let obj be ? ToObject(O).
-        var obj = argumentList[0].ToObject(vm);
+        var obj = O.ToObject(vm);
         if (obj.IsAbruptCompletion()) return obj.Completion;
 
         // 2. Let keys be ? obj.[[OwnPropertyKeys]]().

--- a/JSS.Lib/Usings.cs
+++ b/JSS.Lib/Usings.cs
@@ -1,4 +1,5 @@
-﻿global using Boolean = JSS.Lib.AST.Values.Boolean; 
+﻿global using Array = JSS.Lib.AST.Values.Array;
+global using Boolean = JSS.Lib.AST.Values.Boolean;
 global using Environment = JSS.Lib.Execution.Environment;
 global using ExecutionContext = JSS.Lib.Execution.ExecutionContext;
 global using Object = JSS.Lib.AST.Values.Object;


### PR DESCRIPTION
We now support the required functionality for arrays that is used in propertyHelper.js for test-262.

Mainly, the required functionality for Object.getOwnPropertyNames.

Example Code:
```js
var originalDesc = Object.getOwnPropertyDescriptor(Object, prototype);
// Holds an object with the properties value, writable, enumerable and configurable
var names = Object.getOwnPropertyNames(originalDesc);
// Holds the array [ "value", "writable", "enumerable", "configurable" ] (not guaranteed to be in the same order)
```