### PR TITLE
JSS-18 Ignore whitespace when calling CanConsume on the TokenConsumer

### DIFF
--- a/JSS.Lib/Parser.cs
+++ b/JSS.Lib/Parser.cs
@@ -39,8 +39,10 @@ public sealed class Parser
     {
         List<INode> nodes = new();
 
-        while (shouldParse())
+        while (true)
         {
+            _consumer.IgnoreLineTerminators();
+            if (!shouldParse()) break;
             nodes.Add(ParseStatementListItem());
         }
 

--- a/JSS.Lib/TokenConsumer.cs
+++ b/JSS.Lib/TokenConsumer.cs
@@ -15,25 +15,25 @@ internal sealed class TokenConsumer
 
     public Token Consume()
     {
-        IgnoreLineTerminator();
+        IgnoreLineTerminators();
         return _toConsume[_index++];
     }
 
     public Token Peek(int offset = 0)
     {
-        IgnoreLineTerminator();
+        IgnoreLineTerminators();
         return _toConsume[_index + offset];
     }
 
     public bool IsTokenOfType(TokenType type)
     {
-        IgnoreLineTerminator();
+        IgnoreLineTerminators();
         return CanConsume() && Peek().type == type;
     }
 
     public Token ConsumeTokenOfType(TokenType type)
     {
-        IgnoreLineTerminator();
+        IgnoreLineTerminators();
         if (!CanConsume()) ErrorHelper.ThrowSyntaxError(ErrorType.UnexpectedEOF);
         if (!IsTokenOfType(type)) ErrorHelper.ThrowSyntaxError(ErrorType.UnexpectedToken, Peek().data);
         return Consume();
@@ -45,7 +45,7 @@ internal sealed class TokenConsumer
         return _toConsume[_index].type == TokenType.LineTerminator;
     }
 
-    private void IgnoreLineTerminator()
+    public void IgnoreLineTerminators()
     {
         while (CanConsume() && _toConsume[_index].type == TokenType.LineTerminator) ++_index;
     }


### PR DESCRIPTION
If we're calling CanConsume, we don't want to count whitespace as being something we can consume.

This prevents end of file syntax errors being thrown when trying to parse whitespace at the end of a file.