### PR TITLE
JSS-24 Implement the Array.prototype.push function

### DIFF
--- a/JSS.Lib/AST/Literal/ArrayLiteral.cs
+++ b/JSS.Lib/AST/Literal/ArrayLiteral.cs
@@ -9,7 +9,7 @@ internal sealed class ArrayLiteral : IExpression
     {
         // FIXME: Implement the rest of the evaluation when we parse element lists
         // 1. Let array be ! ArrayCreate(0).
-        var array = MUST(Array.ArrayCreate(0));
+        var array = MUST(Array.ArrayCreate(vm, 0));
 
         // 3. Return array.
         return array;

--- a/JSS.Lib/AST/Values/Array.cs
+++ b/JSS.Lib/AST/Values/Array.cs
@@ -70,10 +70,12 @@ internal sealed class Array : Object
     }
 
     // 10.4.2.2 ArrayCreate ( length [ , proto ] )
-    static public AbruptOr<Array> ArrayCreate(int length, Object? prototype = null)
+    static public AbruptOr<Array> ArrayCreate(VM vm, int length, Object? prototype = null)
     {
         // FIXME: 1. If length > 2**32 - 1, throw a RangeError exception.
-        // FIXME: 2. If proto is not present, set proto to %Array.prototype%.
+
+        // 2. If proto is not present, set proto to %Array.prototype%.
+        prototype ??= vm.ArrayPrototype;
 
         // 3. Let A be MakeBasicObject(« [[Prototype]], [[Extensible]] »).
         // 4. Set A.[[Prototype]] to proto.

--- a/JSS.Lib/AST/Values/List.cs
+++ b/JSS.Lib/AST/Values/List.cs
@@ -20,7 +20,7 @@ internal sealed class List : Value
     public Array CreateArrayFromList(VM vm)
     {
         // 1. Let array be ! ArrayCreate(0).
-        var array = MUST(Array.ArrayCreate(0));
+        var array = MUST(Array.ArrayCreate(vm, 0));
 
         // 2. Let n be 0.
         var n = 0;

--- a/JSS.Lib/AST/Values/Object.cs
+++ b/JSS.Lib/AST/Values/Object.cs
@@ -186,6 +186,17 @@ public class Object : Value
         return asCallable.Call(vm, V, argumentsList);
     }
 
+
+    // 7.3.18 LengthOfArrayLike ( obj ), https://tc39.es/ecma262/#sec-lengthofarraylike
+    internal AbruptOr<double> LengthOfArrayLike()
+    {
+        // 1. Return ℝ(? ToLength(? Get(obj, "length"))).
+        var getResult = Get(this, "length");
+        if (getResult.IsAbruptCompletion()) return getResult;
+
+        return getResult.Value.ToLength();
+    }
+
     // 10.1.1 [[GetPrototypeOf]] ( ), https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof
     internal Object? GetPrototypeOf()
     {

--- a/JSS.Lib/AST/Values/Value.cs
+++ b/JSS.Lib/AST/Values/Value.cs
@@ -782,4 +782,17 @@ public abstract class Value
         // 3. Return SameValueNonNumber(x, y).
         return SameValueNonNumber(x, y);
     }
+
+    // 7.1.20 ToLength ( argument ), https://tc39.es/ecma262/#sec-tolength
+    internal AbruptOr<double> ToLength()
+    {
+        // 1. Let len be ? ToIntegerOrInfinity(argument).
+        var len = ToIntegerOrInfinity();
+
+        // 2. If len ≤ 0, return +0𝔽.
+        if (len.Value <= 0) return 0;
+
+        // 3. Return 𝔽(min(len, 2**53 - 1)).
+        return Math.Min(len.Value, Math.Pow(2, 53) - 1);
+    }
 }

--- a/JSS.Lib/AST/Values/Value.cs
+++ b/JSS.Lib/AST/Values/Value.cs
@@ -374,6 +374,26 @@ public abstract class Value
         throw new NotImplementedException();
     }
 
+    // 7.1.5 ToIntegerOrInfinity ( argument ), https://tc39.es/ecma262/#sec-tointegerorinfinity
+    internal AbruptOr<double> ToIntegerOrInfinity()
+    {
+        // 1. Let number be ? ToNumber(argument).
+        var number = ToNumber();
+        if (number.IsAbruptCompletion()) return number;
+
+        // 2. If number is one of NaN, +0𝔽, FIXME: (or -0𝔽), return 0.
+        if (number.Value is double.NaN or 0) return 0;
+
+        // 3. If number is +∞𝔽, return +∞.
+        if (number.Value == double.PositiveInfinity) return double.PositiveInfinity;
+
+        // 4. If number is -∞𝔽, return -∞.
+        if (number.Value == double.NegativeInfinity) return double.NegativeInfinity;
+
+        // 5. Return truncate(ℝ(number)).
+        return Math.Truncate(number.Value);
+    }
+
     // 7.1.6 ToInt32 ( argument ), https://tc39.es/ecma262/#sec-toint32
     internal AbruptOr<int> ToInt32()
     {

--- a/JSS.Lib/Execution/Realm.cs
+++ b/JSS.Lib/Execution/Realm.cs
@@ -61,7 +61,10 @@ public sealed class Realm
         StringConstructor = new(FunctionPrototype);
 
         ArrayPrototype = new(ObjectPrototype);
+        ArrayConstructor = new(FunctionPrototype);
+
         ArrayPrototype.Initialize(vm);
+        ArrayConstructor.Initialize(this);
 
         ErrorPrototype = new(ObjectPrototype);
         ErrorConstructor = new(FunctionPrototype);
@@ -199,6 +202,9 @@ public sealed class Realm
         // 22.1.1 The String Constructor, https://tc39.es/ecma262/#sec-string-constructor
         globalProperties.Add("String", new Property(StringConstructor, new(true, false, true)));
 
+        // 23.1.1 The Array Constructor, https://tc39.es/ecma262/#sec-array-constructor
+        globalProperties.Add("Array", new Property(ArrayConstructor, new(true, false, true)));
+
         return globalProperties;
     }
 
@@ -260,6 +266,7 @@ public sealed class Realm
     internal FunctionPrototype FunctionPrototype { get; private set; }
     internal StringConstructor StringConstructor { get; private set; }
     internal ArrayPrototype ArrayPrototype { get; private set; }
+    internal ArrayConstructor ArrayConstructor { get; private set; }
     internal ErrorPrototype ErrorPrototype { get; private set; }
     internal ErrorConstructor ErrorConstructor { get; private set; }
     internal NativeErrorPrototype EvalErrorPrototype { get; private set; }

--- a/JSS.Lib/Execution/Realm.cs
+++ b/JSS.Lib/Execution/Realm.cs
@@ -61,6 +61,7 @@ public sealed class Realm
         StringConstructor = new(FunctionPrototype);
 
         ArrayPrototype = new(ObjectPrototype);
+        ArrayPrototype.Initialize(vm);
 
         ErrorPrototype = new(ObjectPrototype);
         ErrorConstructor = new(FunctionPrototype);

--- a/JSS.Lib/Execution/Realm.cs
+++ b/JSS.Lib/Execution/Realm.cs
@@ -60,6 +60,8 @@ public sealed class Realm
 
         StringConstructor = new(FunctionPrototype);
 
+        ArrayPrototype = new(ObjectPrototype);
+
         ErrorPrototype = new(ObjectPrototype);
         ErrorConstructor = new(FunctionPrototype);
         ErrorPrototype.Initialize(this, vm);
@@ -256,6 +258,7 @@ public sealed class Realm
     internal ObjectConstructor ObjectConstructor { get; private set; }
     internal FunctionPrototype FunctionPrototype { get; private set; }
     internal StringConstructor StringConstructor { get; private set; }
+    internal ArrayPrototype ArrayPrototype { get; private set; }
     internal ErrorPrototype ErrorPrototype { get; private set; }
     internal ErrorConstructor ErrorConstructor { get; private set; }
     internal NativeErrorPrototype EvalErrorPrototype { get; private set; }

--- a/JSS.Lib/Execution/ThrowHelper.cs
+++ b/JSS.Lib/Execution/ThrowHelper.cs
@@ -6,6 +6,7 @@ namespace JSS.Lib.Execution;
 enum RuntimeErrorType
 {
     AssignmentToConst,
+    ArrayLengthTooLarge,
     BindingNotDefined,
     BindingThisToAlreadyThisInitializedEnvironment,
     CallingANonFunction,
@@ -86,6 +87,7 @@ internal static class ThrowHelper
     static private readonly Dictionary<RuntimeErrorType, string> errorTypeToFormatString = new()
     {
         { RuntimeErrorType.AssignmentToConst, "invalid assignment to const {0}" },
+        { RuntimeErrorType.ArrayLengthTooLarge, "length {0} too large for array" },
         { RuntimeErrorType.BindingNotDefined, "{0} is not defined" },
         { RuntimeErrorType.BindingThisToAlreadyThisInitializedEnvironment, "tried to bind a this value to already this-initialized function environment" },
         { RuntimeErrorType.CallingANonFunction, "{0} is not a function" },

--- a/JSS.Lib/Execution/VM.cs
+++ b/JSS.Lib/Execution/VM.cs
@@ -30,6 +30,7 @@ public sealed class VM
     internal ObjectPrototype ObjectPrototype { get => Realm.ObjectPrototype; }
     internal ObjectConstructor ObjectConstructor { get => Realm.ObjectConstructor; }
     internal FunctionPrototype FunctionPrototype { get => Realm.FunctionPrototype; }
+    internal ArrayPrototype ArrayPrototype { get => Realm.ArrayPrototype; }
     internal ErrorPrototype ErrorPrototype { get => Realm.ErrorPrototype; }
 
     internal NativeErrorConstructor EvalErrorConstructor { get => Realm.EvalErrorConstructor; }

--- a/JSS.Lib/Runtime/Array.constructor.cs
+++ b/JSS.Lib/Runtime/Array.constructor.cs
@@ -1,0 +1,18 @@
+﻿using JSS.Lib.Execution;
+
+namespace JSS.Lib.Runtime;
+
+// 23.1.1 The Array Constructor, https://tc39.es/ecma262/#sec-array-constructor
+internal sealed class ArrayConstructor : Object
+{
+    // The Array constructor has a [[Prototype]] internal slot whose value is %Function.prototype%.
+    public ArrayConstructor(FunctionPrototype prototype) : base(prototype)
+    {
+    }
+
+    public void Initialize(Realm realm)
+    {
+        // 23.1.2.4 Array.prototype, https://tc39.es/ecma262/#sec-array.prototype
+        DataProperties.Add("prototype", new(realm.ArrayPrototype, new(true, false, true)));
+    }
+}

--- a/JSS.Lib/Runtime/Array.prototype.cs
+++ b/JSS.Lib/Runtime/Array.prototype.cs
@@ -1,0 +1,9 @@
+﻿namespace JSS.Lib.Runtime;
+
+internal sealed class ArrayPrototype : Object
+{
+    // The Array prototype object has a [[Prototype]] internal slot whose value is %Object.prototype%.
+    public ArrayPrototype(ObjectPrototype prototype) : base(prototype)
+    {
+    }
+}

--- a/JSS.Lib/Runtime/Array.prototype.cs
+++ b/JSS.Lib/Runtime/Array.prototype.cs
@@ -3,6 +3,7 @@ using JSS.Lib.Execution;
 
 namespace JSS.Lib.Runtime;
 
+// 23.1.3 Properties of the Array Prototype Object, https://tc39.es/ecma262/#sec-properties-of-the-array-prototype-object
 internal sealed class ArrayPrototype : Object
 {
     // The Array prototype object has a [[Prototype]] internal slot whose value is %Object.prototype%.

--- a/JSS.Lib/Runtime/Array.prototype.cs
+++ b/JSS.Lib/Runtime/Array.prototype.cs
@@ -1,9 +1,57 @@
-﻿namespace JSS.Lib.Runtime;
+﻿using JSS.Lib.AST.Values;
+using JSS.Lib.Execution;
+
+namespace JSS.Lib.Runtime;
 
 internal sealed class ArrayPrototype : Object
 {
     // The Array prototype object has a [[Prototype]] internal slot whose value is %Object.prototype%.
     public ArrayPrototype(ObjectPrototype prototype) : base(prototype)
     {
+    }
+
+    public void Initialize(VM vm)
+    {
+        // 23.1.3.23 Array.prototype.push ( ...items ), https://tc39.es/ecma262/#sec-array.prototype.push
+        var pushBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, push);
+        DataProperties.Add("push", new(pushBuiltin, new(true, false, true)));
+    }
+
+    // 23.1.3.23 Array.prototype.push ( ...items ), https://tc39.es/ecma262/#sec-array.prototype.push
+    public Completion push(VM vm, Value? thisArgument, List argumentList)
+    {
+        // 1. Let O be ? ToObject(this value).
+        var O = thisArgument!.ToObject(vm);
+
+        // 2. Let len be ? LengthOfArrayLike(O).
+        var lenResult = O.Value.LengthOfArrayLike();
+        if (lenResult.IsAbruptCompletion()) return lenResult.Completion;
+        var len = lenResult.Value;
+
+        // 3. Let argCount be the number of elements in items.
+        var argCount = argumentList.Count;
+
+        // FIXME: Overflow errors
+        // 4. If len + argCount > 2**53 - 1, throw a TypeError exception.
+        if (len + argCount > Math.Pow(2, 53) - 1) return ThrowTypeError(vm, RuntimeErrorType.ArrayLengthTooLarge, len + argCount);
+
+        // 5. For each element E of items, do
+        foreach (var e in argumentList.Values)
+        {
+            // FIXME: Don't use C#'s ToString
+            // a. Perform ? Set(O, ! ToString(𝔽(len)), E, true).
+            var setResult = Set(vm, O.Value, len.ToString(), e, true);
+            if (setResult.IsAbruptCompletion()) return setResult;
+
+            // b. Set len to len + 1.
+            len += 1;
+        }
+
+        // 6. Perform ? Set(O, "length", 𝔽(len), true).
+        var lenSetResult = Set(vm, O.Value, "length", len, true);
+        if (lenSetResult.IsAbruptCompletion()) return lenSetResult;
+
+        // 7. Return 𝔽(len).
+        return len;
     }
 }


### PR DESCRIPTION
We now support the Array.prototype.push function for array objects according to the spec.

Example:
```js
var arr = [];
arr.push("1"); // arr is holds ["1"], returns 1
arr.push("2"); // arr is holds ["1", "2"], returns 2
```