### PR TITLE
JSS-26 Implement support for ternary expressions

### DIFF
--- a/JSS.Lib.UnitTests/ASTTests.cs
+++ b/JSS.Lib.UnitTests/ASTTests.cs
@@ -437,6 +437,10 @@ internal sealed class ASTTests
         CreateComputedPropertyExpressionTestCase("true", true),
         CreateComputedPropertyExpressionTestCase("1", 1),
         CreateComputedPropertyExpressionTestCase(EscapeString("1"), "1"),
+
+        // Tests for TernaryExpression
+        CreateTernaryTestCase("true", "1", "2", 1),
+        CreateTernaryTestCase("false", "1", "2", 2),
     };
 
     static private object[] CreateBooleanLiteralTestCase(bool value)
@@ -715,6 +719,11 @@ internal sealed class ASTTests
     static private object[] CreateComputedPropertyExpressionTestCase(string propertyValue, Value expected)
     {
         return new object[] { $"let a = {{}}; a[\"b\"] = {propertyValue}; a[\"b\"]", Completion.NormalCompletion(expected) };
+    }
+
+    static private object[] CreateTernaryTestCase(string testExpression, string trueCase, string falseCase, Value expected)
+    {
+        return new object[] { $"{testExpression} ? {trueCase} : {falseCase}", Completion.NormalCompletion(expected) };
     }
 
     [TestCaseSource(nameof(astTestCases))]

--- a/JSS.Lib.UnitTests/ParserTests.cs
+++ b/JSS.Lib.UnitTests/ParserTests.cs
@@ -54,6 +54,7 @@ internal sealed class ParserTests
         { "this", typeof(ThisExpression) },
         { "(this)", typeof(ThisExpression) },
         { "null", typeof(NullLiteral) },
+        { "1 ? 2 : 3", typeof(TernaryExpression) },
     };
 
     // Tests for Expression, https://tc39.es/ecma262/#prod-Expression
@@ -1757,6 +1758,9 @@ internal sealed class ParserTests
         {"a &=", "}"},
         {"a ^=", "}"},
         {"a |=", "}"},
+        {"a ?", "}"},
+        {"a ? b", "}"},
+        {"a ? b :", "}"},
     };
 
     [TestCaseSource(nameof(unexpectedTokenTestCases))]
@@ -1866,6 +1870,9 @@ internal sealed class ParserTests
         "a &=",
         "a ^=",
         "a |=",
+        "a ?",
+        "a ? b",
+        "a ? b :",
     };
 
     [TestCaseSource(nameof(unexpectedEofTestCases))]

--- a/JSS.Lib/AST/TernaryExpression.cs
+++ b/JSS.Lib/AST/TernaryExpression.cs
@@ -1,0 +1,16 @@
+﻿namespace JSS.Lib.AST;
+
+// 13.14 Conditional Operator ( ? : ), https://tc39.es/ecma262/#prod-ConditionalExpression
+internal sealed class TernaryExpression : IExpression
+{
+    public TernaryExpression(IExpression testExpression, IExpression trueCaseExpression,  IExpression falseCaseExpression)
+    {
+        TestExpression = testExpression;
+        TrueCaseExpression = trueCaseExpression;
+        FalseCaseExpression = falseCaseExpression;
+    }
+
+    public IExpression TestExpression { get; }
+    public IExpression TrueCaseExpression { get; }
+    public IExpression FalseCaseExpression { get; }
+}

--- a/JSS.Lib/AST/TernaryExpression.cs
+++ b/JSS.Lib/AST/TernaryExpression.cs
@@ -1,4 +1,6 @@
-﻿namespace JSS.Lib.AST;
+﻿using JSS.Lib.Execution;
+
+namespace JSS.Lib.AST;
 
 // 13.14 Conditional Operator ( ? : ), https://tc39.es/ecma262/#prod-ConditionalExpression
 internal sealed class TernaryExpression : IExpression
@@ -8,6 +10,40 @@ internal sealed class TernaryExpression : IExpression
         TestExpression = testExpression;
         TrueCaseExpression = trueCaseExpression;
         FalseCaseExpression = falseCaseExpression;
+    }
+
+    // 13.14.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#prod-ConditionalExpression
+    public override Completion Evaluate(VM vm)
+    {
+        // 1. Let lref be ? Evaluation of ShortCircuitExpression.
+        var lref = TestExpression.Evaluate(vm);
+        if (lref.IsAbruptCompletion()) return lref;
+
+        // 2. Let lval be ToBoolean(? GetValue(lref)).
+        var getResult = lref.Value.GetValue(vm);
+        if (getResult.IsAbruptCompletion()) return getResult;
+        var lval = getResult.Value.ToBoolean();
+
+        // 3. If lval is true, then
+        if (lval)
+        {
+            // a. Let trueRef be ? Evaluation of the first AssignmentExpression.
+            var trueRef = TrueCaseExpression.Evaluate(vm);
+            if (trueRef.IsAbruptCompletion()) return trueRef;
+
+            // b. Return ? GetValue(trueRef).
+            return trueRef.Value.GetValue(vm);
+        }
+        // 4. Else,
+        else
+        {
+            // a. Let falseRef be ? Evaluation of the second AssignmentExpression.
+            var falseRef = FalseCaseExpression.Evaluate(vm);
+            if (falseRef.IsAbruptCompletion()) return falseRef;
+
+            // b. Return ? GetValue(falseRef).
+            return falseRef.Value.GetValue(vm);
+        }
     }
 
     public IExpression TestExpression { get; }


### PR DESCRIPTION
We now can parse and execute ternary expressions.

Example Code:
```js
var a = true ? 1 : 2; // a holds 1
var b = false ? 1 : 2; // a holds 2
```