### PR TITLE
JSS-27 Implement execution of delete expressions

### DIFF
--- a/JSS.Lib/AST/DeleteExpression.cs
+++ b/JSS.Lib/AST/DeleteExpression.cs
@@ -1,4 +1,7 @@
-﻿namespace JSS.Lib.AST;
+﻿using JSS.Lib.Execution;
+using System.Diagnostics;
+
+namespace JSS.Lib.AST;
 
 // 13.5.1 The delete Operator, https://tc39.es/ecma262/#sec-delete-operator
 internal sealed class DeleteExpression : IExpression
@@ -8,7 +11,60 @@ internal sealed class DeleteExpression : IExpression
         Expression = expression;
     }
 
-    // FIXME: 13.5.1.2 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-delete-operator-runtime-semantics-evaluation
+    // 13.5.1.2 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-delete-operator-runtime-semantics-evaluation
+    public override Completion Evaluate(VM vm)
+    {
+        // 1. Let ref be ? Evaluation of UnaryExpression.
+        var uref = Expression.Evaluate(vm);
+        if (uref.IsAbruptCompletion()) return uref;
+
+        // 2. If ref is not a Reference Record, return true.
+        if (!uref.Value.IsReference()) return true;
+        var asReference = uref.Value.AsReference();
+
+        // 3. If IsUnresolvableReference(ref) is true, then
+        if (asReference.IsUnresolvableReference())
+        {
+            // FIXME: a. Assert: ref.[[Strict]] is false.
+
+            // b. Return true.
+            return true;
+        }
+
+        // 4. If IsPropertyReference(ref) is true, then
+        if (asReference.IsPropertyReference())
+        {
+            // FIXME: a. Assert: IsPrivateReference(ref) is false.
+
+            // FIXME: b. If IsSuperReference(ref) is true, throw a ReferenceError exception.
+
+            // c. Let baseObj be ? ToObject(ref.[[Base]]).
+            var baseObj = asReference.Base!.ToObject(vm);
+            if (baseObj.IsAbruptCompletion()) return baseObj.Completion;
+
+            // d. Let deleteStatus be ? baseObj.[[Delete]](ref.[[ReferencedName]]).
+            var deleteStatus = baseObj.Value.Delete(asReference.ReferencedName);
+            if (deleteStatus.IsAbruptCompletion()) return deleteStatus.Completion;
+
+            // FIXME: e. If deleteStatus is false and ref.[[Strict]] is true, throw a TypeError exception.
+
+            // f. Return deleteStatus.
+            return deleteStatus.Value;
+        }
+        // 5. Else,
+        else
+        {
+            // a. Let base be ref.[[Base]].
+            var baseEnv = asReference.Base;
+
+            // b. Assert: base is an Environment Record.
+            Debug.Assert(baseEnv is Environment);
+
+            // c. Return ? base.DeleteBinding(ref.[[ReferencedName]]).
+            var asEnvironment = baseEnv.AsEnvironment();
+            return asEnvironment.DeleteBinding(asReference.ReferencedName);
+        }
+    }
 
     public IExpression Expression { get; }
 }

--- a/JSS.Lib/AST/Values/Object.cs
+++ b/JSS.Lib/AST/Values/Object.cs
@@ -13,7 +13,7 @@ public class Object : Value
     }
 
     override public bool IsObject() { return true; }
-    override public ValueType Type() {  return ValueType.Object; }
+    override public ValueType Type() { return ValueType.Object; }
 
     public string ToString(VM vm)
     {
@@ -182,7 +182,7 @@ public class Object : Value
         }
 
         // 3. Return ? F.[[Call]](V, argumentsList).
-        var asCallable = F.AsCallable(); 
+        var asCallable = F.AsCallable();
         return asCallable.Call(vm, V, argumentsList);
     }
 
@@ -357,6 +357,38 @@ public class Object : Value
         }
 
         return true;
+    }
+
+    // 10.1.10 [[Delete]] ( P ), https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-delete-p
+    internal AbruptOr<bool> Delete(string P)
+    {
+        // 1. Return ? OrdinaryDelete(O, P).
+        return OrdinaryDelete(P);
+    }
+
+    // 10.1.10.1 OrdinaryDelete ( O, P ), https://tc39.es/ecma262/#sec-ordinarydelete
+    internal AbruptOr<bool> OrdinaryDelete(string P)
+    {
+        // 1. Let desc be ? O.[[GetOwnProperty]](P).
+        var desc = GetOwnProperty(P);
+        if (desc.IsAbruptCompletion()) return desc;
+
+        // 2. If desc is undefined, return true.
+        if (desc.Value.IsUndefined()) return true;
+
+        // 3. If desc.[[Configurable]] is true, then
+        var asProperty = desc.Value.AsProperty();
+        if (asProperty.Attributes.Configurable)
+        {
+            // a. Remove the own property with name P from O.
+            DataProperties.Remove(P);
+
+            // b. Return true.
+            return true;
+        }
+
+        // 4. Return false.
+        return false;
     }
 
     // 10.1.11 [[OwnPropertyKeys]] ( ), https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys

--- a/JSS.Lib/Execution/DeclarativeEnvironment.cs
+++ b/JSS.Lib/Execution/DeclarativeEnvironment.cs
@@ -134,6 +134,21 @@ internal class DeclarativeEnvironment : Environment
         return binding.Value;
     }
 
+    // 9.1.1.1.7 DeleteBinding ( N ), https://tc39.es/ecma262/#sec-declarative-environment-records-deletebinding-n
+    public override Completion DeleteBinding(string N)
+    {
+        // 1. Assert: envRec has a binding for N.
+        Debug.Assert(_identifierToBinding.ContainsKey(N));
+
+        // 2. If the binding for N in envRec cannot be deleted, return false.
+
+        // 3. Remove the binding for N from envRec.
+        _identifierToBinding.Remove(N);
+
+        // 4. Return true.
+        return true;
+    }
+
     // 9.1.1.1.8 HasThisBinding ( ), https://tc39.es/ecma262/#sec-declarative-environment-records-hasthisbinding
     override public bool HasThisBinding()
     {

--- a/JSS.Lib/Execution/ObjectEnvironment.cs
+++ b/JSS.Lib/Execution/ObjectEnvironment.cs
@@ -114,6 +114,16 @@ internal sealed class ObjectEnvironment : Environment
         return Object.Get(BindingObject, N);
     }
 
+    // 9.1.1.2.7 DeleteBinding ( N ), https://tc39.es/ecma262/#sec-object-environment-records-deletebinding-n
+    public override Completion DeleteBinding(string N)
+    {
+        // 1. Let bindingObject be envRec.[[BindingObject]].
+        // 2. Return ? bindingObject.[[Delete]](N).
+        var result = BindingObject.Delete(N);
+        if (result.IsAbruptCompletion()) return result.Completion;
+        return result.Value;
+    }
+
     // 9.1.1.2.8 HasThisBinding ( ), https://tc39.es/ecma262/#sec-object-environment-records-hasthisbinding
     override public bool HasThisBinding()
     {


### PR DESCRIPTION
We now support execution of delete expressions. This allows for
object properties or environment bindings to be deleted from them.

The property or binding will no longer exist after delete being called
on them.

Example Code:
```js
delete Array.prototype; // Array.prototype now returns undefined
```