### PR TITLE
JSS-30 Implement the pow function on the MathObject

### DIFF
--- a/JSS.Lib/Execution/Realm.cs
+++ b/JSS.Lib/Execution/Realm.cs
@@ -102,6 +102,7 @@ public sealed class Realm
         URIErrorConstructor.Initialize(URIErrorPrototype, "URIError");
 
         MathObject = new(ObjectPrototype);
+        MathObject.Initialize(vm);
 
         // FIMXE: 3. Perform AddRestrictedFunctionProperties(realmRec.[[Intrinsics]].[[%Function.prototype%]], realmRec).
 

--- a/JSS.Lib/Execution/Realm.cs
+++ b/JSS.Lib/Execution/Realm.cs
@@ -101,6 +101,8 @@ public sealed class Realm
         URIErrorPrototype.Initialize(URIErrorConstructor, "URIError");
         URIErrorConstructor.Initialize(URIErrorPrototype, "URIError");
 
+        MathObject = new(ObjectPrototype);
+
         // FIMXE: 3. Perform AddRestrictedFunctionProperties(realmRec.[[Intrinsics]].[[%Function.prototype%]], realmRec).
 
         // 4. Return UNUSED.
@@ -205,6 +207,10 @@ public sealed class Realm
         // 23.1.1 The Array Constructor, https://tc39.es/ecma262/#sec-array-constructor
         globalProperties.Add("Array", new Property(ArrayConstructor, new(true, false, true)));
 
+        // 19.4 Other Properties of the Global Object, https://tc39.es/ecma262/#sec-other-properties-of-the-global-object
+        // 21.3 The Math Object, https://tc39.es/ecma262/#sec-math-object
+        globalProperties.Add("Math", new Property(MathObject, new(true, false, true)));
+
         return globalProperties;
     }
 
@@ -281,4 +287,5 @@ public sealed class Realm
     internal NativeErrorConstructor TypeErrorConstructor { get; private set; }
     internal NativeErrorPrototype URIErrorPrototype { get; private set; }
     internal NativeErrorConstructor URIErrorConstructor { get; private set; }
+    internal MathObject MathObject { get; private set; }
 }

--- a/JSS.Lib/Runtime/MathObject.cs
+++ b/JSS.Lib/Runtime/MathObject.cs
@@ -1,4 +1,7 @@
-﻿namespace JSS.Lib.Runtime;
+﻿using JSS.Lib.AST.Values;
+using JSS.Lib.Execution;
+
+namespace JSS.Lib.Runtime;
 
 // 21.3 The Math Object, https://tc39.es/ecma262/#sec-math-object
 internal sealed class MathObject : Object
@@ -6,5 +9,27 @@ internal sealed class MathObject : Object
     // The Math object has a [[Prototype]] internal slot whose value is %Object.prototype%.
     public MathObject(ObjectPrototype prototype) : base(prototype)
     {
+    }
+
+    public void Initialize(VM vm)
+    {
+        // 21.3.2.26 Math.pow ( base, exponent ), https://tc39.es/ecma262/#sec-math.pow
+        var powBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, pow);
+        DataProperties.Add("pow", new(powBuiltin, new(true, false, true)));
+    }
+
+    // 21.3.2.26 Math.pow ( base, exponent ), https://tc39.es/ecma262/#sec-math.pow
+    private Completion pow(VM vm, Value? thisArgument, List argumentList)
+    {
+        // 1. Set base to ? ToNumber(base).
+        var powBase = argumentList[0].ToNumber();
+        if (powBase.IsAbruptCompletion()) return powBase.Completion;
+
+        // 2. Set exponent to ? ToNumber(exponent).
+        var exponent = argumentList[1].ToNumber();
+        if (exponent.IsAbruptCompletion()) return exponent.Completion;
+
+        // 3. Return Number::exponentiate(base, exponent).
+        return Number.Exponentiate(powBase.Value, exponent.Value);
     }
 }

--- a/JSS.Lib/Runtime/MathObject.cs
+++ b/JSS.Lib/Runtime/MathObject.cs
@@ -1,0 +1,10 @@
+﻿namespace JSS.Lib.Runtime;
+
+// 21.3 The Math Object, https://tc39.es/ecma262/#sec-math-object
+internal sealed class MathObject : Object
+{
+    // The Math object has a [[Prototype]] internal slot whose value is %Object.prototype%.
+    public MathObject(ObjectPrototype prototype) : base(prototype)
+    {
+    }
+}


### PR DESCRIPTION
This allows for the pow function to be called from the math object. This
function calculate the power of two numbers.

Example Code:
```js
Math.pow(2, 2); // Returns 4
Math.pow(2, 3); // Returns 8
```