### PR TITLE
JSS-32 Implement the push function on the Array.prototype

### DIFF
--- a/JSS.Lib/Runtime/Array.prototype.cs
+++ b/JSS.Lib/Runtime/Array.prototype.cs
@@ -1,5 +1,6 @@
 ﻿using JSS.Lib.AST.Values;
 using JSS.Lib.Execution;
+using System.Text;
 
 namespace JSS.Lib.Runtime;
 
@@ -13,13 +14,81 @@ internal sealed class ArrayPrototype : Object
 
     public void Initialize(VM vm)
     {
+        // 23.1.3.18 Array.prototype.join ( separator ), https://tc39.es/ecma262/#sec-array.prototype.join
+        var joinBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, join);
+        DataProperties.Add("join", new(joinBuiltin, new(true, false, true)));
+
         // 23.1.3.23 Array.prototype.push ( ...items ), https://tc39.es/ecma262/#sec-array.prototype.push
         var pushBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, push);
         DataProperties.Add("push", new(pushBuiltin, new(true, false, true)));
     }
 
+    // 23.1.3.18 Array.prototype.join ( separator ), https://tc39.es/ecma262/#sec-array.prototype.join
+    private Completion join(VM vm, Value? thisArgument, List argumentList)
+    {
+        // 1. Let O be ? ToObject(this value).
+        var O = thisArgument!.ToObject(vm);
+        if (O.IsAbruptCompletion()) return O.Completion;
+
+        // 2. Let len be ? LengthOfArrayLike(O).
+        var lenResult = O.Value.LengthOfArrayLike();
+        if (lenResult.IsAbruptCompletion()) return lenResult;
+        var len = (int)lenResult.Value;
+
+        // 3. If separator is undefined, let sep be ",".
+        string sep;
+        if (argumentList[0].IsUndefined())
+        {
+            sep = ",";
+        }
+        // 4. Else, let sep be ? ToString(separator).
+        else
+        {
+            var toString = argumentList[0].ToStringJS(vm);
+            if (toString.IsAbruptCompletion()) return toString.Completion;
+            sep = toString.Value;
+        }
+
+        // 5. Let R be the empty String.
+        StringBuilder R = new();
+
+        // 6. Let k be 0.
+        var k = 0;
+
+        // 7. Repeat, while k < len,
+        while (k < len)
+        {
+            // a. If k > 0, set R to the string-concatenation of R and sep.
+            if (k > 0)
+            {
+                R.Append(sep);
+            }
+
+            // b. Let element be ? Get(O, ! ToString(𝔽(k))).
+            var element = Get(O.Value, k.ToString());
+            if (element.IsAbruptCompletion()) return element;
+
+            // c. If element is neither undefined nor null, then
+            if (!element.Value.IsUndefined() && !element.Value.IsNull())
+            {
+                // i. Let S be ? ToString(element).
+                var S = element.Value.ToStringJS(vm);
+                if (S.IsAbruptCompletion()) return S.Completion;
+
+                // ii. Set R to the string-concatenation of R and S.
+                R.Append(S.Value);
+            }
+
+            // d. Set k to k + 1.
+            k += 1;
+        }
+
+        // 8. Return R.
+        return R.ToString();
+    }
+
     // 23.1.3.23 Array.prototype.push ( ...items ), https://tc39.es/ecma262/#sec-array.prototype.push
-    public Completion push(VM vm, Value? thisArgument, List argumentList)
+    private Completion push(VM vm, Value? thisArgument, List argumentList)
     {
         // 1. Let O be ? ToObject(this value).
         var O = thisArgument!.ToObject(vm);


### PR DESCRIPTION
We now implement the push function on the Array.prototype. This provides the funcitonality to create a string consisting of the elements of the array seperated by the provided or default seperator.

```js
var arr = [];
arr.push(1);
arr.join(); // Returns "1"
arr.push(2);
arr.join(); // Returns "1,2"
arr.join("; "); // Returns "1; 2"
```