### PR TITLE
JSS-38 Implement execution of test-262 test cases

### DIFF
--- a/JSS.Test262Runner/Program.cs
+++ b/JSS.Test262Runner/Program.cs
@@ -7,3 +7,6 @@ test262RepositoryCloner.CloneRepositoryIfNotAlreadyPresent();
 Console.WriteLine("\nStarting the test-262 runner...");
 var test262Runner = new Test262Runner();
 test262Runner.StartRunner();
+
+Console.WriteLine("\nPress ENTER to exit.");
+Console.ReadLine();


### PR DESCRIPTION
When StartRunner is called on a Test262Runner, we enumerate every JavaScript file in the test directory and evaluate them in individual realms and vms as required by test-262.

We currently have limited logging and only have success and failure instead of more detailed failure reasons (e.g. a parsing error).