### PR TITLE
JSS-40 Parse and handle test-262 metadata in our runner.

### DIFF
--- a/JSS.Common/Print.cs
+++ b/JSS.Common/Print.cs
@@ -98,4 +98,17 @@ public sealed class Print
         Console.BackgroundColor = ConsoleColor.Red;
         Console.ForegroundColor = ConsoleColor.White;
     }
+
+    static public string GetErrorNameFromValue(Value value)
+    {
+        if (!value.IsObject()) return "";
+
+        var asObject = value.AsObject();
+        if (!asObject.DataProperties.TryGetValue("name", out var errorProperty)) return "";
+
+        var errorName = errorProperty.Value;
+        if (!errorName.IsString()) return "";
+
+        return errorName.AsString();
+    }
 }

--- a/JSS.Test262Runner/JSS.Test262Runner.csproj
+++ b/JSS.Test262Runner/JSS.Test262Runner.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="YamlDotNet" Version="15.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\JSS.Common\JSS.Common.csproj" />
     <ProjectReference Include="..\JSS.Lib\JSS.Lib.csproj" />
   </ItemGroup>

--- a/JSS.Test262Runner/Test262Exceptions.cs
+++ b/JSS.Test262Runner/Test262Exceptions.cs
@@ -26,3 +26,11 @@ internal class HarnessExecutionFailureException : Test262Exception
     public HarnessExecutionFailureException(string message) : base(message) { }
     public HarnessExecutionFailureException(VM vm, Completion completion) : base(vm, completion) { }
 }
+
+/// <summary>
+/// Indicated that parsing of a test-262 test case metadata failed.
+/// </summary>
+internal class MetadataParsingFailureException : Test262Exception
+{
+    public MetadataParsingFailureException(string message) : base(message) { }
+}

--- a/JSS.Test262Runner/Test262Metadata.cs
+++ b/JSS.Test262Runner/Test262Metadata.cs
@@ -1,0 +1,88 @@
+﻿using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace JSS.Test262Runner;
+
+/// <summary>
+/// Holds the needed parsed metadata of a test-262 test case.
+/// </summary>
+internal sealed record Test262Metadata
+{
+    private Test262Metadata(Metadata metadata)
+    {
+        _metadata = metadata;
+    }
+
+    static public Test262Metadata Create(string testCase)
+    {
+        try
+        {
+            var yamlString = GetYAMLFromTestCase(testCase);
+            var deserializer = new DeserializerBuilder()
+                .IgnoreUnmatchedProperties()
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .Build();
+            var metadata = deserializer.Deserialize<Metadata>(yamlString);
+            return new Test262Metadata(metadata);
+        }
+        catch (Exception ex)
+        {
+            throw new MetadataParsingFailureException(ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Retrieves the YAML metadata from a test-262 test case.
+    /// </summary>
+    /// <param name="testCase">A test-262 test case that contains YAML metadata.</param>
+    /// <returns>A string that holds the YAML metadata of a test case.</returns>
+    static private string GetYAMLFromTestCase(string testCase)
+    {
+        // Each test file may define metadata that describe additional requirements. This information is delimited by the token sequence /*--- and ---*/ and is structured as YAML.
+        const int DELIMITER_SIZE = 5;
+        var yamlStart = testCase.IndexOf("/*---");
+        var yamlEnd = testCase.IndexOf("---*/");
+
+        if (yamlStart == -1 || yamlEnd == -1) throw new MetadataParsingFailureException("Could not find the YAML delimiters for test case.");
+
+        return testCase.Substring(yamlStart + DELIMITER_SIZE, yamlEnd - yamlStart - DELIMITER_SIZE);
+    }
+
+    // NOTE: We don't want to expose these classes as we just want the abstracted properties of the outer class
+    sealed record Metadata
+    {
+        public NegativeTestMetadata? Negative { get; set; }
+        public List<string>? Includes { get; set; }
+        public HashSet<string>? Flags { get; set; }
+    }
+
+    enum NegativeTestPhase
+    {
+        Parse,
+        Resolution,
+        Runtime
+    }
+
+    sealed record NegativeTestMetadata
+    {
+        public NegativeTestPhase Phase { get; set; }
+        public required string Type { get; set; }
+    }
+
+    public TestResultType ExpectedTestResultType => _metadata.Negative?.Phase switch
+    {
+        NegativeTestPhase.Parse => TestResultType.PARSING_FAILURE,
+        NegativeTestPhase.Resolution => throw new MetadataParsingFailureException("Found negative module resolution test case, but there is no support for modules yet."),
+        NegativeTestPhase.Runtime => TestResultType.FAILURE,
+        null => TestResultType.SUCCESS,
+        _ => throw new MetadataParsingFailureException($"Found invalid negative test case phase of {_metadata.Negative!.Phase}."),
+    };
+
+    public bool IsExpectedNegativeErrorType(string actualType) => actualType == _metadata.Negative!.Type;
+
+    public List<string> Includes => _metadata.Includes ?? [];
+
+    public bool HasFlag(string flag) => _metadata.Flags?.Contains(flag) ?? false;
+
+    private readonly Metadata _metadata;
+}

--- a/JSS.Test262Runner/Test262Metadata.cs
+++ b/JSS.Test262Runner/Test262Metadata.cs
@@ -69,16 +69,18 @@ internal sealed record Test262Metadata
         public required string Type { get; set; }
     }
 
+    public bool IsNegativeTestCase => _metadata.Negative is not null;
+    public string NegativeTestCaseType => _metadata.Negative!.Type;
     public TestResultType ExpectedTestResultType => _metadata.Negative?.Phase switch
     {
         NegativeTestPhase.Parse => TestResultType.PARSING_FAILURE,
-        NegativeTestPhase.Resolution => throw new MetadataParsingFailureException("Found negative module resolution test case, but there is no support for modules yet."),
+        NegativeTestPhase.Resolution => TestResultType.PARSING_FAILURE, // FIXME: When we have support for modules, determine if this is right
         NegativeTestPhase.Runtime => TestResultType.FAILURE,
         null => TestResultType.SUCCESS,
         _ => throw new MetadataParsingFailureException($"Found invalid negative test case phase of {_metadata.Negative!.Phase}."),
     };
 
-    public bool IsExpectedNegativeErrorType(string actualType) => actualType == _metadata.Negative!.Type;
+    public bool IsExpectedNegativeErrorType(string actualType) => actualType == (_metadata.Negative?.Type ?? "");
 
     public List<string> Includes => _metadata.Includes ?? [];
 

--- a/JSS.Test262Runner/Test262Runner.cs
+++ b/JSS.Test262Runner/Test262Runner.cs
@@ -7,6 +7,7 @@ namespace JSS.Test262Runner;
 enum TestResultType
 {
     SUCCESS,
+    METADATA_PARSING_FAILURE,
     HARNESS_EXECUTION_FAILURE,
     PARSING_FAILURE,
     CRASH_FAILURE,
@@ -80,6 +81,7 @@ internal sealed class Test262Runner
         return new()
         {
             { TestResultType.SUCCESS, 0 },
+            { TestResultType.METADATA_PARSING_FAILURE, 0 },
             { TestResultType.HARNESS_EXECUTION_FAILURE, 0 },
             { TestResultType.PARSING_FAILURE, 0 },
             { TestResultType.CRASH_FAILURE, 0 },
@@ -94,8 +96,10 @@ internal sealed class Test262Runner
     /// <returns>The result of executing the test case.</returns>
     private TestResult ExecuteTestCase(string testCase)
     {
+        Test262Metadata testCaseMetadata;
         try
         {
+            testCaseMetadata = Test262Metadata.Create(testCase);
             var testCaseVm = CreateTestCaseVM();
             var testCaseScript = ParseAsGlobalCode(testCaseVm, testCase);
             var testCompletion = testCaseScript.ScriptEvaluation();
@@ -106,6 +110,10 @@ internal sealed class Test262Runner
             }
 
             return new(TestResultType.SUCCESS);
+        }
+        catch (MetadataParsingFailureException ex)
+        {
+            return new(TestResultType.METADATA_PARSING_FAILURE, ex.Message);
         }
         catch (HarnessExecutionFailureException ex)
         {
@@ -224,6 +232,7 @@ internal sealed class Test262Runner
     static private readonly Dictionary<TestResultType, string> TEST_RESULT_TYPE_TO_EMOJI = new()
     {
         { TestResultType.SUCCESS, "✅" },
+        { TestResultType.METADATA_PARSING_FAILURE, "📝️" },
         { TestResultType.HARNESS_EXECUTION_FAILURE, "⚙️" },
         { TestResultType.PARSING_FAILURE, "✍️" },
         { TestResultType.CRASH_FAILURE, "💥" },


### PR DESCRIPTION
We now parse and handle test-262 metadata in our runner.

This provides support for evaluating extra required harness files, the "raw" flag and test cases that are expected to fail.