### PR TITLE
JSS-42 Don't spam the CI console when running our test-262 runner

### DIFF
--- a/.github/workflows/test-262-runner.yml
+++ b/.github/workflows/test-262-runner.yml
@@ -32,4 +32,4 @@ jobs:
       run: dotnet build --no-restore --configuration Release JSS.Test262Runner/JSS.Test262Runner.csproj
     - name: Start our Test262Runner
     # NOTE: the "|| cd ." is a hack so the error code is always 0, see the NOTE on continue-on-error
-      run: dotnet run --no-build --configuration Release --project JSS.Test262Runner/JSS.Test262Runner.csproj || cd .
+      run: dotnet run --no-build --configuration Release --project JSS.Test262Runner/JSS.Test262Runner.csproj -- -q || cd .

--- a/JSS.Test262Runner/CommandLineOptions.cs
+++ b/JSS.Test262Runner/CommandLineOptions.cs
@@ -1,0 +1,10 @@
+﻿using CommandLine;
+
+namespace JSS.Test262Runner;
+
+internal sealed class CommandLineOptions
+{
+    [Option('q', "quiet", FlagCounter = true, HelpText = "Enables quiet mode. Won't output results for every test executed.")]
+    public int QuietCount { get; set; }
+    public bool Quiet => QuietCount > 0;
+}

--- a/JSS.Test262Runner/JSS.Test262Runner.csproj
+++ b/JSS.Test262Runner/JSS.Test262Runner.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="YamlDotNet" Version="15.1.2" />
   </ItemGroup>
 

--- a/JSS.Test262Runner/Program.cs
+++ b/JSS.Test262Runner/Program.cs
@@ -1,4 +1,5 @@
 ﻿// TODO: Setup ILogger (or something similar) that we can use for this project
+using CommandLine;
 using JSS.Test262Runner;
 using System.Text;
 
@@ -7,6 +8,10 @@ test262RepositoryCloner.CloneRepositoryIfNotAlreadyPresent();
 
 Console.OutputEncoding = Encoding.UTF8;
 
-Console.WriteLine("\nStarting the test-262 runner...");
-var test262Runner = new Test262Runner();
-test262Runner.StartRunner();
+Parser.Default.ParseArguments<CommandLineOptions>(args)
+    .WithParsed(options =>
+    {
+        Console.WriteLine("\nStarting the test-262 runner...");
+        var test262Runner = new Test262Runner(options);
+        test262Runner.StartRunner();
+    });


### PR DESCRIPTION
We now have a "quiet" mode for our test-262 runner. This mode only reports the progress every 100 tests executed.

We now also use this mode in our CI job, as to not spam the output.