### PR TITLE
JSS-44 Implement a command line argument for filtering tests

### DIFF
--- a/JSS.Test262Runner/CommandLineOptions.cs
+++ b/JSS.Test262Runner/CommandLineOptions.cs
@@ -7,4 +7,8 @@ internal sealed class CommandLineOptions
     [Option('q', "quiet", FlagCounter = true, HelpText = "Enables quiet mode. Won't output results for every test executed.")]
     public int QuietCount { get; set; }
     public bool Quiet => QuietCount > 0;
+
+    [Option('f', "filter", Default = "*.js",
+        HelpText = "Filters tests to execute based on their path. * is a wildcard for zero or more characters and ? is a wildcard for zero or one characters.")]
+    public required string Filter { get; set; }
 }

--- a/JSS.Test262Runner/Test262Runner.cs
+++ b/JSS.Test262Runner/Test262Runner.cs
@@ -56,17 +56,10 @@ internal sealed class Test262Runner
     /// </summary>
     public void StartRunner()
     {
-        // Modules, Test262 includes tests for ECMAScript 2015 module code, denoted by the "module" metadata flag.
-        // Files bearing a name which includes the sequence _FIXTURE MUST NOT be interpreted as standalone tests; they are intended to be referenced by test files.
-        const string TEST_FIXTURE = "_FIXTURE";
-        const string TEST_DIRECTORY = "./test262/test";
-        const string TEST_FILTER = "*.js";
+        var testFiles = GetTestCasePathsToExecute();
+        if (testFiles is null) return;
 
         var testResults = CreateTestResultsDictionary();
-
-        var testFiles = Directory.EnumerateFiles(TEST_DIRECTORY, TEST_FILTER, SearchOption.AllDirectories)
-            .Where(x => !x.Contains(TEST_FIXTURE));
-
         var testCounter = 0;
         var testCount = testFiles.Count();
         foreach (var testFile in testFiles)
@@ -88,6 +81,34 @@ internal sealed class Test262Runner
         }
 
         LogTestRunStatistics(testCount, testResults);
+    }
+
+    /// <summary>
+    /// Gets the paths of test case files to execute or null if command line filter is incorrect.
+    /// </summary>
+    /// <returns>An enumerable containing the paths of test cases to execute or null if command line filter is incorrect.</returns>
+    private IEnumerable<string>? GetTestCasePathsToExecute()
+    {
+        // Modules, Test262 includes tests for ECMAScript 2015 module code, denoted by the "module" metadata flag.
+        // Files bearing a name which includes the sequence _FIXTURE MUST NOT be interpreted as standalone tests; they are intended to be referenced by test files.
+        const string TEST_FIXTURE = "_FIXTURE";
+        const string TEST_DIRECTORY = "./test262/test";
+
+        var filter = _options.Filter;
+        if (!_options.Filter.EndsWith(".js")) filter += ".js";
+
+        try
+        {
+            return Directory.EnumerateFiles(TEST_DIRECTORY, filter, SearchOption.AllDirectories)
+                .Where(x => !x.Contains(TEST_FIXTURE));
+        }
+        catch
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine($"The filter {filter} is invalid.");
+            Console.ResetColor();
+            return null;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
We now have a command line argument for filtering tests "-f" or "--filter". This is useful for only running test-262 on a specific set of tests that are being actively worked on.