### PR TITLE
JSS-43 Implement the "$262" object for the test 262 runner

### DIFF
--- a/JSS.Lib/Execution/Realm.cs
+++ b/JSS.Lib/Execution/Realm.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using JSS.Lib.AST.Values;
 using JSS.Lib.Runtime;
 
@@ -107,6 +106,19 @@ public sealed class Realm
         // FIMXE: 3. Perform AddRestrictedFunctionProperties(realmRec.[[Intrinsics]].[[%Function.prototype%]], realmRec).
 
         // 4. Return UNUSED.
+    }
+
+    // Host-Defined Functions, https://github.com/tc39/test262/blob/main/INTERPRETING.md
+    static public Completion CreateTest262HostDefinedFunctions(VM vm)
+    {
+        // The following values must be defined as writable, configurable, non-enumerable properties of the global scope prior to test execution.
+
+        // $262, An ordinary object
+        var test262Object = new Test262Object(vm.ObjectPrototype);
+        var defineResult = Object.DefinePropertyOrThrow(vm, vm.Realm.GlobalObject, "$262", new Property(test262Object, new(true, false, true)));
+        if (defineResult.IsAbruptCompletion()) return defineResult;
+
+        return Empty.The;
     }
 
     // 9.3.3 SetRealmGlobalObject ( realmRec, globalObj, thisValue ), https://tc39.es/ecma262/#sec-setrealmglobalobject

--- a/JSS.Lib/Execution/Realm.cs
+++ b/JSS.Lib/Execution/Realm.cs
@@ -115,6 +115,7 @@ public sealed class Realm
 
         // $262, An ordinary object
         var test262Object = new Test262Object(vm.ObjectPrototype);
+        test262Object.Initialize(vm);
         var defineResult = Object.DefinePropertyOrThrow(vm, vm.Realm.GlobalObject, "$262", new Property(test262Object, new(true, false, true)));
         if (defineResult.IsAbruptCompletion()) return defineResult;
 

--- a/JSS.Lib/Runtime/Test262Object.cs
+++ b/JSS.Lib/Runtime/Test262Object.cs
@@ -1,8 +1,30 @@
-﻿namespace JSS.Lib.Runtime;
+﻿using JSS.Lib.AST.Values;
+using JSS.Lib.Execution;
+
+namespace JSS.Lib.Runtime;
 
 internal sealed class Test262Object : Object
 {
     public Test262Object(ObjectPrototype prototype) : base(prototype)
     {
+    }
+
+    public void Initialize(VM vm)
+    {
+        var createRealmBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, createRealm);
+        DataProperties.Add("createRealm", new Property(createRealmBuiltin, new(true, false, true)));
+    }
+
+    private Completion createRealm(VM _, Value? thisValue, List argumentList)
+    {
+        // createRealm - a function which creates a new ECMAScript Realm, defines this API on the new realm's global object,
+        // and returns the $262 property of the new realm's global object
+        var initializeCompletion = Realm.InitializeHostDefinedRealm(out VM newVm);
+        if (initializeCompletion.IsAbruptCompletion()) return initializeCompletion;
+
+        var test262DefiningCompletion = Realm.CreateTest262HostDefinedFunctions(newVm);
+        if (test262DefiningCompletion.IsAbruptCompletion()) return test262DefiningCompletion;
+
+        return newVm.Realm.GlobalObject.DataProperties["$262"].Value;
     }
 }

--- a/JSS.Lib/Runtime/Test262Object.cs
+++ b/JSS.Lib/Runtime/Test262Object.cs
@@ -19,6 +19,9 @@ internal sealed class Test262Object : Object
 
         var gcBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, gc);
         DataProperties.Add("gc", new Property(gcBuiltin, new(true, false, true)));
+
+        // global, a reference to the global object on which $262 was initially defined
+        DataProperties.Add("global", new Property(vm.Realm.GlobalObject, new(true, false, true)));
     }
 
     private Completion createRealm(VM _, Value? thisValue, List argumentList)
@@ -65,6 +68,7 @@ internal sealed class Test262Object : Object
 
     private Completion gc(VM vm, Value? thisValue, List argumentList)
     {
+        // gc, a function that wraps the host's garbage collection invocation mechanism
         GC.Collect();
         return Undefined.The;
     }

--- a/JSS.Lib/Runtime/Test262Object.cs
+++ b/JSS.Lib/Runtime/Test262Object.cs
@@ -1,0 +1,8 @@
+﻿namespace JSS.Lib.Runtime;
+
+internal sealed class Test262Object : Object
+{
+    public Test262Object(ObjectPrototype prototype) : base(prototype)
+    {
+    }
+}

--- a/JSS.Lib/Runtime/Test262Object.cs
+++ b/JSS.Lib/Runtime/Test262Object.cs
@@ -16,6 +16,9 @@ internal sealed class Test262Object : Object
 
         var evalScriptBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, evalScript);
         DataProperties.Add("evalScript", new Property(evalScriptBuiltin, new(true, false, true)));
+
+        var gcBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, gc);
+        DataProperties.Add("gc", new Property(gcBuiltin, new(true, false, true)));
     }
 
     private Completion createRealm(VM _, Value? thisValue, List argumentList)
@@ -58,5 +61,11 @@ internal sealed class Test262Object : Object
         // 5. Let status be ScriptEvaluation(s).
         // 6. Return Completion(status).
         return s!.ScriptEvaluation();
+    }
+
+    private Completion gc(VM vm, Value? thisValue, List argumentList)
+    {
+        GC.Collect();
+        return Undefined.The;
     }
 }

--- a/JSS.Test262Runner/Test262Runner.cs
+++ b/JSS.Test262Runner/Test262Runner.cs
@@ -171,10 +171,16 @@ internal sealed class Test262Runner
     /// <returns>An isolated VM with its own dedicated ECMAScript realm as specified in INTERPRETING.md</returns>
     private VM CreateTestCaseVM(Test262Metadata metadata)
     {
-        var completion = Realm.InitializeHostDefinedRealm(out VM testCaseVm);
-        if (completion.IsAbruptCompletion())
+        var initializeCompletion = Realm.InitializeHostDefinedRealm(out VM testCaseVm);
+        if (initializeCompletion.IsAbruptCompletion())
         {
-            throw new HarnessExecutionFailureException(testCaseVm, completion);
+            throw new HarnessExecutionFailureException(testCaseVm, initializeCompletion);
+        }
+
+        var test262DefiningCompletion = Realm.CreateTest262HostDefinedFunctions(testCaseVm);
+        if (test262DefiningCompletion.IsAbruptCompletion())
+        {
+            throw new HarnessExecutionFailureException(testCaseVm, test262DefiningCompletion);
         }
 
         // raw: The test source code must not be modified in any way, files from the harness/directory must not be evaluated,


### PR DESCRIPTION
[INTERPRETING.md](https://github.com/tc39/test262/blob/main/INTERPRETING.md) tells us to define a "$262" object with specific functions and properties.

We now defined this object in our runner and implement the properties and methods that we currently support.