### PR TITLE
JSS-20 Make the thisValue not nullable for BuiltinFunctions

### DIFF
--- a/JSS.Lib/AST/Values/BuiltinFunction.cs
+++ b/JSS.Lib/AST/Values/BuiltinFunction.cs
@@ -7,7 +7,7 @@ namespace JSS.Lib.AST.Values;
 internal sealed class BuiltinFunction : Object, ICallable, IConstructable
 {
 #pragma warning disable CS8618 // All properties are initialised in OrdinaryFunctionCreate
-    private BuiltinFunction(Object prototype, Func<VM, Value?, List, Completion> behaviour) : base(prototype)
+    private BuiltinFunction(Object prototype, Func<VM, Value, List, Completion> behaviour) : base(prototype)
     {
         Behaviour = behaviour;
     }
@@ -47,10 +47,11 @@ internal sealed class BuiltinFunction : Object, ICallable, IConstructable
         // 9. Push calleeContext onto the execution context stack; calleeContext is now the running execution context.
         vm.PushExecutionContext(calleeContext);
 
+        // NOTE: Technically a null thisArgument should have no value, but having a value of undefined serves the same purpose and is not visible in JavaScript.
         // 10. Let result be the Completion Record that is the result of evaluating F in a manner that conforms to the specification of F.
         // If thisArgument is UNINITIALIZED, the this value is uninitialized; otherwise, thisArgument provides the this value.
         // argumentsList provides the named parameters. newTarget provides the NewTarget value.
-        var result = Behaviour(vm, thisArgument, argumentsList);
+        var result = Behaviour(vm, thisArgument ?? Undefined.The, argumentsList);
 
         // 11. NOTE: If F is defined in this document, “the specification of F” is the behaviour specified for it via algorithm steps or other means.
 
@@ -62,7 +63,7 @@ internal sealed class BuiltinFunction : Object, ICallable, IConstructable
     }
 
     // 10.3.4 CreateBuiltinFunction ( behaviour, FIXME: length, FIXME: name, FIXME: additionalInternalSlotsList [ , realm [ , prototype [ , FIXME: prefix ] ] ] ), https://tc39.es/ecma262/#sec-createbuiltinfunction
-    static public BuiltinFunction CreateBuiltinFunction(VM vm, Func<VM, Value?, List, Completion> behaviour, Realm? realm = null, Object? prototype = null)
+    static public BuiltinFunction CreateBuiltinFunction(VM vm, Func<VM, Value, List, Completion> behaviour, Realm? realm = null, Object? prototype = null)
     {
         // 1. If realm is not present, set realm to the current Realm Record.
         realm ??= vm.Realm;
@@ -98,6 +99,6 @@ internal sealed class BuiltinFunction : Object, ICallable, IConstructable
         return func;
     }
 
-    public Func<VM, Value?, List, Completion> Behaviour { get; private set; }
+    public Func<VM, Value, List, Completion> Behaviour { get; private set; }
     public Realm Realm { get; private set; }
 }

--- a/JSS.Lib/Runtime/Array.constructor.cs
+++ b/JSS.Lib/Runtime/Array.constructor.cs
@@ -22,7 +22,7 @@ internal sealed class ArrayConstructor : Object
     }
 
     // 23.1.2.2 Array.isArray ( arg ), https://tc39.es/ecma262/#sec-array.isarray
-    private Completion isArray(VM vm, Value? thisArgument, List argumentList)
+    private Completion isArray(VM vm, Value thisArgument, List argumentList)
     {
         // 1. Return ? IsArray(arg).
         return argumentList[0].IsArray();

--- a/JSS.Lib/Runtime/Array.prototype.cs
+++ b/JSS.Lib/Runtime/Array.prototype.cs
@@ -24,10 +24,10 @@ internal sealed class ArrayPrototype : Object
     }
 
     // 23.1.3.18 Array.prototype.join ( separator ), https://tc39.es/ecma262/#sec-array.prototype.join
-    private Completion join(VM vm, Value? thisArgument, List argumentList)
+    private Completion join(VM vm, Value thisArgument, List argumentList)
     {
         // 1. Let O be ? ToObject(this value).
-        var O = thisArgument!.ToObject(vm);
+        var O = thisArgument.ToObject(vm);
         if (O.IsAbruptCompletion()) return O.Completion;
 
         // 2. Let len be ? LengthOfArrayLike(O).
@@ -88,10 +88,10 @@ internal sealed class ArrayPrototype : Object
     }
 
     // 23.1.3.23 Array.prototype.push ( ...items ), https://tc39.es/ecma262/#sec-array.prototype.push
-    private Completion push(VM vm, Value? thisArgument, List argumentList)
+    private Completion push(VM vm, Value thisArgument, List argumentList)
     {
         // 1. Let O be ? ToObject(this value).
-        var O = thisArgument!.ToObject(vm);
+        var O = thisArgument.ToObject(vm);
 
         // 2. Let len be ? LengthOfArrayLike(O).
         var lenResult = O.Value.LengthOfArrayLike();

--- a/JSS.Lib/Runtime/Error.prototype.cs
+++ b/JSS.Lib/Runtime/Error.prototype.cs
@@ -28,12 +28,12 @@ internal sealed class ErrorPrototype : Object
     }
 
     // 20.5.3.4 Error.prototype.toString ( ), https://tc39.es/ecma262/#sec-error.prototype.tostring
-    private Completion toString(VM vm, Value? thisArgument, List argumentList)
+    private Completion toString(VM vm, Value thisArgument, List argumentList)
     {
         // 1. Let O be the this value.
 
         // 2. If O is not an Object, throw a TypeError exception.
-        if (thisArgument is null || !thisArgument.IsObject()) return ThrowTypeError(vm, RuntimeErrorType.ThisIsNotAnObject);
+        if (!thisArgument.IsObject()) return ThrowTypeError(vm, RuntimeErrorType.ThisIsNotAnObject);
 
         // 3. Let name be ? Get(O, "name").
         var O = thisArgument.AsObject();

--- a/JSS.Lib/Runtime/Function.prototype.cs
+++ b/JSS.Lib/Runtime/Function.prototype.cs
@@ -19,13 +19,13 @@ internal sealed class FunctionPrototype : Object
     }
 
     // 20.2.3.3 Function.prototype.call ( thisArg, ...args ), https://tc39.es/ecma262/#sec-function.prototype.call
-    private Completion call(VM vm, Value? thisArg, List argumentList)
+    private Completion call(VM vm, Value thisArg, List argumentList)
     {
         // 1. Let func be the this value.
         var func = thisArg;
 
         // 2. If IsCallable(func) is false, throw a TypeError exception.
-        if (func is null || !func.IsCallable()) return ThrowTypeError(vm, RuntimeErrorType.CallingANonFunction, func?.Type() ?? ValueType.Undefined);
+        if (!func.IsCallable()) return ThrowTypeError(vm, RuntimeErrorType.CallingANonFunction, func?.Type() ?? ValueType.Undefined);
 
         // FIXME: 3. Perform PrepareForTailCall().
 

--- a/JSS.Lib/Runtime/MathObject.cs
+++ b/JSS.Lib/Runtime/MathObject.cs
@@ -19,7 +19,7 @@ internal sealed class MathObject : Object
     }
 
     // 21.3.2.26 Math.pow ( base, exponent ), https://tc39.es/ecma262/#sec-math.pow
-    private Completion pow(VM vm, Value? thisArgument, List argumentList)
+    private Completion pow(VM vm, Value thisArgument, List argumentList)
     {
         // 1. Set base to ? ToNumber(base).
         var powBase = argumentList[0].ToNumber();

--- a/JSS.Lib/Runtime/Object.constructor.cs
+++ b/JSS.Lib/Runtime/Object.constructor.cs
@@ -58,7 +58,7 @@ internal class ObjectConstructor : Object, ICallable, IConstructable
     }
 
     // 20.1.2.4 Object.defineProperty ( O, P, Attributes ), https://tc39.es/ecma262/#sec-object.defineproperty
-    private Completion defineProperty(VM vm, Value? thisArgument, List argumentList)
+    private Completion defineProperty(VM vm, Value thisArgument, List argumentList)
     {
         // 1. If O is not an Object, throw a TypeError exception.
         var O = argumentList[0];
@@ -80,7 +80,7 @@ internal class ObjectConstructor : Object, ICallable, IConstructable
     }
 
     // 20.1.2.8 Object.getOwnPropertyDescriptor ( O, P ), https://tc39.es/ecma262/#sec-object.getownpropertydescriptor
-    private Completion getOwnPropertyDescriptor(VM vm, Value? thisArgument, List argumentList)
+    private Completion getOwnPropertyDescriptor(VM vm, Value thisArgument, List argumentList)
     {
         // 1. Let obj be ? ToObject(O).
         var obj = argumentList[0].ToObject(vm);
@@ -100,7 +100,7 @@ internal class ObjectConstructor : Object, ICallable, IConstructable
     }
 
     // 20.1.2.10 Object.getOwnPropertyNames ( O ), https://tc39.es/ecma262/#sec-object.getownpropertynames
-    private Completion getOwnPropertyNames(VM vm, Value? thisArgument, List argumentList)
+    private Completion getOwnPropertyNames(VM vm, Value thisArgument, List argumentList)
     {
         // 1. Return CreateArrayFromList(? GetOwnPropertyKeys(O, STRING)).
         var ownPropertyKeys = GetOwnPropertyKeys(vm, argumentList[0]);

--- a/JSS.Lib/Runtime/Object.prototype.cs
+++ b/JSS.Lib/Runtime/Object.prototype.cs
@@ -26,7 +26,7 @@ internal class ObjectPrototype : Object
     }
 
     // 20.1.3.2 Object.prototype.hasOwnProperty ( V ), https://tc39.es/ecma262/#sec-object.prototype.hasownproperty
-    private Completion hasOwnProperty(VM vm, Value? thisValue, List argumentList)
+    private Completion hasOwnProperty(VM vm, Value thisValue, List argumentList)
     {
         // 1. Let P be ? ToPropertyKey(V).
         var P = argumentList[0].ToPropertyKey(vm);
@@ -41,10 +41,10 @@ internal class ObjectPrototype : Object
     }
 
     // 20.1.3.6 Object.prototype.toString ( ), https://tc39.es/ecma262/#sec-object.prototype.tostring
-    private Completion toString(VM vm, Value? thisValue, List argumentList)
+    private Completion toString(VM vm, Value thisValue, List argumentList)
     {
         // 1. If the this value is undefined, return "[object Undefined]".
-        if (thisValue is null || thisValue.IsUndefined()) return "[object Undefined]";
+        if (thisValue.IsUndefined()) return "[object Undefined]";
 
         // 2. If the this value is null, return "[object Null]".
         if (thisValue.IsNull()) return "[object Null]";

--- a/JSS.Lib/Runtime/Test262Object.cs
+++ b/JSS.Lib/Runtime/Test262Object.cs
@@ -24,7 +24,7 @@ internal sealed class Test262Object : Object
         DataProperties.Add("global", new Property(vm.Realm.GlobalObject, new(true, false, true)));
     }
 
-    private Completion createRealm(VM _, Value? thisValue, List argumentList)
+    private Completion createRealm(VM _, Value thisValue, List argumentList)
     {
         // createRealm - a function which creates a new ECMAScript Realm, defines this API on the new realm's global object,
         // and returns the $262 property of the new realm's global object
@@ -38,7 +38,7 @@ internal sealed class Test262Object : Object
     }
 
     // evalScript - a function which accepts a string value as its first argument and executes it as an ECMAScript script
-    private Completion evalScript(VM vm, Value? thisValue, List argumentList)
+    private Completion evalScript(VM vm, Value thisValue, List argumentList)
     {
         // 1. Let hostDefined be any host-defined values for the provide sourceText (obtained in an implementation dependent manner)
         var sourceText = argumentList[0].AsString();
@@ -66,7 +66,7 @@ internal sealed class Test262Object : Object
         return s!.ScriptEvaluation();
     }
 
-    private Completion gc(VM vm, Value? thisValue, List argumentList)
+    private Completion gc(VM vm, Value thisValue, List argumentList)
     {
         // gc, a function that wraps the host's garbage collection invocation mechanism
         GC.Collect();


### PR DESCRIPTION
BuiltinFunctions can have an "uninitialized" state, however, providing undefined provides the same symantics and has no visibility outside C#.