### PR TITLE
JSS-48 Throw our own "AssertionException" instead of using Debug.Assert

### DIFF
--- a/JSS.Lib/AST/BitwiseNotExpression.cs
+++ b/JSS.Lib/AST/BitwiseNotExpression.cs
@@ -37,7 +37,7 @@ internal sealed class BitwiseNotExpression : IExpression
         else
         {
             // a. Assert: oldValue is a BigInt.
-            Debug.Assert(oldValue.Value.IsBigInt());
+            Assert(oldValue.Value.IsBigInt(), "a. Assert: oldValue is a BigInt.");
 
             // FIXME: b. Return BigInt::bitwiseNOT(oldValue).
             throw new NotImplementedException();

--- a/JSS.Lib/AST/CallExpression.cs
+++ b/JSS.Lib/AST/CallExpression.cs
@@ -69,7 +69,7 @@ internal sealed class CallExpression : IExpression
                 var refEnv = asReference.Base;
 
                 // ii. Assert: refEnv is an Environment Record.
-                Debug.Assert(refEnv is Environment);
+                Assert(refEnv is Environment, "Assert: refEnv is an Environment Record.");
 
                 // iii. Let thisValue be refEnv.WithBaseObject().
                 var asEnvironment = refEnv as Environment;

--- a/JSS.Lib/AST/DeleteExpression.cs
+++ b/JSS.Lib/AST/DeleteExpression.cs
@@ -58,7 +58,7 @@ internal sealed class DeleteExpression : IExpression
             var baseEnv = asReference.Base;
 
             // b. Assert: base is an Environment Record.
-            Debug.Assert(baseEnv is Environment);
+            Assert(baseEnv is Environment, "b. Assert: base is an Environment Record.");
 
             // c. Return ? base.DeleteBinding(ref.[[ReferencedName]]).
             var asEnvironment = baseEnv.AsEnvironment();

--- a/JSS.Lib/AST/PostfixDecrementExpression.cs
+++ b/JSS.Lib/AST/PostfixDecrementExpression.cs
@@ -38,7 +38,7 @@ internal sealed class PostfixDecrementExpression : IExpression
         else
         {
             // a. Assert: oldValue is a BigInt.
-            Debug.Assert(oldValue.Value.IsBigInt());
+            Assert(oldValue.Value.IsBigInt(), "a. Assert: oldValue is a BigInt.");
 
             // FIXME: b. Let newValue be BigInt::subtract(oldValue, 1ℤ).
             throw new NotImplementedException();

--- a/JSS.Lib/AST/PostfixIncrementExpression.cs
+++ b/JSS.Lib/AST/PostfixIncrementExpression.cs
@@ -37,7 +37,7 @@ internal sealed class PostfixIncrementExpression : IExpression
         else
         {
             // a. Assert: oldValue is a BigInt.
-            Debug.Assert(oldValue.Value.IsBigInt());
+            Assert(oldValue.Value.IsBigInt(), "a. Assert: oldValue is a BigInt.");
 
             // FIXME: b. Let newValue be BigInt::add(oldValue, 1ℤ).
             throw new NotImplementedException();

--- a/JSS.Lib/AST/PrefixDecrementExpression.cs
+++ b/JSS.Lib/AST/PrefixDecrementExpression.cs
@@ -38,7 +38,7 @@ internal sealed class PrefixDecrementExpression : IExpression
         else
         {
             // a. Assert: oldValue is a BigInt.
-            Debug.Assert(oldValue.Value.IsBigInt());
+            Assert(oldValue.Value.IsBigInt(), "a. Assert: oldValue is a BigInt.");
 
             // FIXME: b. Let newValue be BigInt::subtract(oldValue, 1ℤ).
             throw new NotImplementedException();

--- a/JSS.Lib/AST/PrefixIncrementExpression.cs
+++ b/JSS.Lib/AST/PrefixIncrementExpression.cs
@@ -37,7 +37,7 @@ internal sealed class PrefixIncrementExpression : IExpression
         else
         {
             // a. Assert: oldValue is a BigInt.
-            Debug.Assert(oldValue.Value.IsBigInt());
+            Assert(oldValue.Value.IsBigInt(), "a. Assert: oldValue is a BigInt.");
 
             // FIXME: b. Let newValue be BigInt::add(oldValue, 1ℤ).
             throw new NotImplementedException();

--- a/JSS.Lib/AST/TypeOfExpression.cs
+++ b/JSS.Lib/AST/TypeOfExpression.cs
@@ -77,7 +77,7 @@ internal sealed class TypeOfExpression : IExpression
         }
 
         // 11. Assert: val is an Object.
-        Debug.Assert(val.Value.IsObject());
+        Assert(val.Value.IsObject(), "11. Assert: val is an Object.");
 
         // 12. NOTE: This step is replaced in section B.3.6.3.
 

--- a/JSS.Lib/AST/UnaryMinusExpression.cs
+++ b/JSS.Lib/AST/UnaryMinusExpression.cs
@@ -37,7 +37,7 @@ internal sealed class UnaryMinusExpression : IExpression
         else
         {
             // a. Assert: oldValue is a BigInt.
-            Debug.Assert(oldValue.Value.IsBigInt());
+            Assert(oldValue.Value.IsBigInt(), "a. Assert: oldValue is a BigInt.");
 
             // FIXME: b. Return BigInt::unaryMinus(oldValue).
             throw new NotImplementedException();

--- a/JSS.Lib/AST/Values/Array.cs
+++ b/JSS.Lib/AST/Values/Array.cs
@@ -27,13 +27,13 @@ internal sealed class Array : Object
 
             // FIXME: b. Assert: IsDataDescriptor(lengthDesc) is true.
             // c. Assert: lengthDesc.[[Configurable]] is false.
-            Debug.Assert(!lengthDesc.Attributes.Configurable);
+            Assert(!lengthDesc.Attributes.Configurable, "c. Assert: lengthDesc.[[Configurable]] is false.");
 
             // d. Let length be lengthDesc.[[Value]].
             var length = lengthDesc.Value.AsNumber();
 
             // e. Assert: length is a non-negative integral Number.
-            Debug.Assert(length >= 0 && double.IsInteger(length));
+            Assert(length >= 0 && double.IsInteger(length), "e. Assert: length is a non-negative integral Number.");
 
             // f. Let index be ! ToUint32(P).
             var pString = new String(P);
@@ -58,7 +58,7 @@ internal sealed class Array : Object
                 succeeded = MUST(OrdinaryDefineOwnProperty(this, "length", lengthDesc)).AsBoolean();
 
                 // iii. Assert: succeeded is true.
-                Debug.Assert(succeeded);
+                Assert(succeeded, "iii. Assert: succeeded is true.");
             }
 
             // k. Return true.
@@ -114,7 +114,7 @@ internal sealed class Array : Object
 
         // FIXME: 8. Assert: IsDataDescriptor(oldLenDesc) is true.
         // 9. Assert: oldLenDesc.[[Configurable]] is false.
-        Debug.Assert(!oldLenDesc.Attributes.Configurable);
+        Assert(!oldLenDesc.Attributes.Configurable, "9. Assert: oldLenDesc.[[Configurable]] is false.");
 
         // 10. Let oldLen be oldLenDesc.[[Value]].
         var oldLen = oldLenDesc.Value.AsNumber();

--- a/JSS.Lib/AST/Values/FunctionObject.cs
+++ b/JSS.Lib/AST/Values/FunctionObject.cs
@@ -36,7 +36,7 @@ internal sealed class FunctionObject : Object, ICallable, IConstructable
         var calleeContext = (PrepareForOrdinaryCall(vm, Undefined.The) as ScriptExecutionContext)!;
 
         // 3. Assert: calleeContext is now the running execution context.
-        Debug.Assert(vm.CurrentExecutionContext == calleeContext);
+        Assert(vm.CurrentExecutionContext == calleeContext, "3. Assert: calleeContext is now the running execution context.");
 
         // FIXME: 4. If F.[[IsClassConstructor]] is true, then
         // FIXME: a. Let error be a newly created TypeError object.
@@ -129,7 +129,7 @@ internal sealed class FunctionObject : Object, ICallable, IConstructable
                 var globalEnv = calleeRealm.GlobalEnv;
 
                 // ii. Assert: globalEnv is a Global Environment Record.
-                Debug.Assert(globalEnv is GlobalEnvironment);
+                Assert(globalEnv is GlobalEnvironment, "ii. Assert: globalEnv is a Global Environment Record.");
 
                 // iii. Let thisValue be globalEnv.[[GlobalThisValue]].
                 thisValue = globalEnv.GlobalThisValue;
@@ -145,7 +145,7 @@ internal sealed class FunctionObject : Object, ICallable, IConstructable
         }
 
         // 7. Assert: localEnv is a Function Environment Record.
-        Debug.Assert(localEnv is FunctionEnvironment);
+        Assert(localEnv is FunctionEnvironment, "7. Assert: localEnv is a Function Environment Record.");
 
         // 8. Assert: The next step never returns an abrupt completion because localEnv.[[ThisBindingStatus]] is not INITIALIZED.
 
@@ -196,7 +196,7 @@ internal sealed class FunctionObject : Object, ICallable, IConstructable
         var calleeContext = (PrepareForOrdinaryCall(vm, Undefined.The) as ScriptExecutionContext)!;
 
         // 5. Assert: calleeContext is now the running execution context.
-        Debug.Assert(vm.CurrentExecutionContext == calleeContext);
+        Assert(vm.CurrentExecutionContext == calleeContext, "5. Assert: calleeContext is now the running execution context.");
 
         // 6. If kind is BASE, then
         if (ConstructorKind == ConstructorKind.BASE)
@@ -243,7 +243,7 @@ internal sealed class FunctionObject : Object, ICallable, IConstructable
         if (thisBinding.IsAbruptCompletion()) return thisBinding;
 
         // 13. Assert: thisBinding is an Object.
-        Debug.Assert(thisBinding.Value is Object);
+        Assert(thisBinding.Value is Object, "13. Assert: thisBinding is an Object.");
 
         // 14. Return thisBinding.
         return thisBinding;
@@ -352,7 +352,7 @@ internal sealed class FunctionObject : Object, ICallable, IConstructable
     public void SetFunctionName(VM vm, string name, string prefix = "")
     {
         // 1. Assert: FIXME: (F is an extensible object) that does not have a "name" own property.
-        Debug.Assert(!DataProperties.ContainsKey("name"));
+        Assert(!DataProperties.ContainsKey("name"), "1. Assert: F is an extensible object that does not have a \"name\" own property.");
 
         // FIXME: 2. If name is a Symbol, then
         // FIXME: a. Let description be name's [[Description]] value.
@@ -421,8 +421,7 @@ internal sealed class FunctionObject : Object, ICallable, IConstructable
             // a. If d is neither a VariableDeclaration nor a ForBinding nor a BindingIdentifier, then
             if (d is not VarDeclaration or Identifier)
             {
-                // i. Assert: d is either a FunctionDeclaration, a GeneratorDeclaration, an AsyncFunctionDeclaration, or an AsyncGeneratorDeclaration.
-                Debug.Assert(d is FunctionDeclaration);
+                Assert(d is FunctionDeclaration, "i. Assert: d is either a FunctionDeclaration, a GeneratorDeclaration, an AsyncFunctionDeclaration, or an AsyncGeneratorDeclaration.");
 
                 // ii. Let fn be the sole element of the BoundNames of d.
                 var fn = d.BoundNames().FirstOrDefault()!;
@@ -476,7 +475,7 @@ internal sealed class FunctionObject : Object, ICallable, IConstructable
         var env = new DeclarativeEnvironment(calleeEnv);
 
         // d. Assert: The VariableEnvironment of calleeContext is calleeEnv.
-        Debug.Assert(calleeContext.VariableEnvironment == calleeEnv);
+        Assert(calleeContext.VariableEnvironment == calleeEnv, "d. Assert: The VariableEnvironment of calleeContext is calleeEnv.");
 
         // e. Set the LexicalEnvironment of calleeContext to env.
         calleeContext.LexicalEnvironment = env;

--- a/JSS.Lib/AST/Values/Object.cs
+++ b/JSS.Lib/AST/Values/Object.cs
@@ -124,7 +124,7 @@ public class Object : Value
     static internal void CreateNonEnumerableDataPropertyOrThrow(VM vm, Object O, string P, Value V)
     {
         // 1. Assert: O is an ordinary, FIXME: extensible object with no non-configurable properties.
-        Debug.Assert(O.IsObject());
+        Assert(O.IsObject(), "1. Assert: O is an ordinary, extensible object with no non-configurable properties.");
 
         // 2. Let newDesc be the PropertyDescriptor { [[Value]]: V, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }.
         var newDesc = new Property(V, new(true, false, true));
@@ -407,7 +407,7 @@ public class Object : Value
         else
         {
             // i. Assert: Receiver does not currently have a property P.
-            Debug.Assert(!receiver.DataProperties.ContainsKey(P));
+            Assert(!receiver.DataProperties.ContainsKey(P), "i. Assert: Receiver does not currently have a property P.");
 
             // ii. Return ? CreateDataProperty(Receiver, P, V).
             var result = CreateDataProperty(receiver, P, V);

--- a/JSS.Lib/AST/Values/Reference.cs
+++ b/JSS.Lib/AST/Values/Reference.cs
@@ -47,7 +47,7 @@ public class Reference : Value
     internal Value GetThisValue()
     {
         // 1. Assert: IsPropertyReference(V) is true.
-        Debug.Assert(IsPropertyReference());
+        Assert(IsPropertyReference(), "1. Assert: IsPropertyReference(V) is true.");
 
         // FIXME: (2. If IsSuperReference(V) is true, return V.[[ThisValue]];) otherwise return V.[[Base]].
         return Base ?? Undefined.The;
@@ -57,12 +57,12 @@ public class Reference : Value
     public Completion InitializeReferencedBinding(VM vm, Value W)
     {
         // 1. Assert: IsUnresolvableReference(V) is false.
-        Debug.Assert(!IsUnresolvableReference());
+        Assert(!IsUnresolvableReference(), "1. Assert: IsUnresolvableReference(V) is false.");
 
         // 2. Let base be V.[[Base]].
 
         // 3. Assert: base is an Environment Record.
-        Debug.Assert(Base!.IsEnvironment());
+        Assert(Base!.IsEnvironment(), "3. Assert: base is an Environment Record.");
 
         // 4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
         var environment = Base.AsEnvironment();

--- a/JSS.Lib/AST/Values/Value.cs
+++ b/JSS.Lib/AST/Values/Value.cs
@@ -46,55 +46,55 @@ public abstract class Value
 
     public Reference AsReference()
     {
-        Debug.Assert(IsReference());
+        Assert(IsReference(), $"AsReference called on a(n) {ToString()}.");
         return (this as Reference)!;
     }
 
     internal Environment AsEnvironment()
     {
-        Debug.Assert(IsEnvironment());
+        Assert(IsEnvironment(), $"AsEnvironment called on a(n) {ToString()}.");
         return (this as Environment)!;
     }
 
     public Boolean AsBoolean()
     {
-        Debug.Assert(IsBoolean());
+        Assert(IsBoolean(), $"AsBoolean called on a(n) {ToString()}.");
         return (this as Boolean)!;
     }
 
     public String AsString()
     {
-        Debug.Assert(IsString());
+        Assert(IsString(), $"AsString called on a(n) {ToString()}.");
         return (this as String)!;
     }
 
     public Number AsNumber()
     {
-        Debug.Assert(IsNumber());
+        Assert(IsNumber(), $"AsNumber called on a(n) {ToString()}.");
         return (this as Number)!;
     }
 
     public Object AsObject()
     {
-        Debug.Assert(IsObject());
+        Assert(IsObject(), $"AsObject called on a(n) {ToString()}.");
         return (this as Object)!;
     }
 
     internal Property AsProperty()
     {
-        Debug.Assert(IsProperty());
+        Assert(IsProperty(), $"AsProperty called on a(n) {ToString()}.");
         return (this as Property)!;
     }
 
     internal ICallable AsCallable()
     {
-        Debug.Assert(HasInternalCall());
+        Assert(HasInternalCall(), $"AsCallable called on a(n) {ToString()}.");
         return (this as ICallable)!;
     }
 
     internal IConstructable AsConstructable()
     {
-        Debug.Assert(HasInternalConstruct());
+        Assert(HasInternalConstruct(), $"AsConstructable called on a(n) {ToString()}.");
         return (this as IConstructable)!;
     }
 
@@ -140,7 +140,7 @@ public abstract class Value
             var @base = asReference.Base!;
 
             // b. Assert: base is an Environment Record.
-            Debug.Assert(@base.IsEnvironment());
+            Assert(@base.IsEnvironment(), "b. Assert: base is an Environment Record.");
 
             // c. Return ? base.GetBindingValue(V.[[ReferencedName]], FIXME: V.[[Strict]]) (see 9.1).
             var environment = @base.AsEnvironment();
@@ -200,7 +200,7 @@ public abstract class Value
             var @base = reference.Base!;
 
             // b. Assert: base is an Environment Record.
-            Debug.Assert(@base.IsEnvironment());
+            Assert(@base.IsEnvironment(), "b. Assert: base is an Environment Record.");
 
             // c. Return ? base.SetMutableBinding(V.[[ReferencedName]], W, FIXME: V.[[Strict]]) (see 9.1).
             var environment = @base.AsEnvironment();
@@ -568,14 +568,14 @@ public abstract class Value
         // FIXME: 8. If argument is a BigInt, return BigInt::toString(argument, 10).
 
         // 9. Assert: argument is an Object.
-        Debug.Assert(IsObject());
+        Assert(IsObject(), "9. Assert: argument is an Object.");
 
         // 10. Let primValue be ? ToPrimitive(argument, STRING).
         var primValue = ToPrimitive(vm, PreferredType.STRING);
         if (primValue.IsAbruptCompletion()) return primValue;
 
         // 11. Assert: primValue is not an Object.
-        Debug.Assert(!primValue.Value.IsObject());
+        Assert(!primValue.Value.IsObject(), "11. Assert: primValue is not an Object.");
 
         // 12. Return ? ToString(primValue).
         return primValue.Value.ToStringJS(vm);
@@ -682,7 +682,7 @@ public abstract class Value
     static internal Boolean SameValueNonNumber(Value x, Value y)
     {
         // 1. Assert: Type(x) is Type(y).
-        Debug.Assert(x.Type().Equals(y.Type()));
+        Assert(x.Type().Equals(y.Type()), "1. Assert: Type(x) is Type(y).");
 
         // 2. If x is either null or undefined, return true.
         if (x.IsNull() || x.IsUndefined())

--- a/JSS.Lib/AssertionException.cs
+++ b/JSS.Lib/AssertionException.cs
@@ -1,0 +1,17 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace JSS.Lib;
+
+internal sealed class AssertionException : Exception
+{
+    public AssertionException() : base() { }
+    public AssertionException(string? message) : base(message) { }
+    public AssertionException(string? message, Exception? innerException) : base(message, innerException) { }
+
+    static public void Assert([DoesNotReturnIf(false)] bool shouldBeTrue, string message)
+    {
+        if (shouldBeTrue) return;
+
+        throw new AssertionException($"Assertion Failed! {message}");
+    }
+}

--- a/JSS.Lib/Execution/Completion.cs
+++ b/JSS.Lib/Execution/Completion.cs
@@ -89,7 +89,8 @@ public sealed class Completion
     public void UpdateEmpty(Value value)
     {
         // 1. Assert: If completionRecord.[[Type]] is either RETURN or THROW, then completionRecord.[[Value]] is not EMPTY.
-        Debug.Assert(!(IsReturnCompletion() || IsThrowCompletion()) || !IsValueEmpty());
+        Assert(!(IsReturnCompletion() || IsThrowCompletion()) || !IsValueEmpty(),
+            "1. Assert: If completionRecord.[[Type]] is either RETURN or THROW, then completionRecord.[[Value]] is not EMPTY.");
 
         // 2. If completionRecord.[[Value]] is not EMPTY, return ? completionRecord.
         if (!IsValueEmpty()) return;
@@ -149,7 +150,7 @@ internal static class CompletionHelper
         // 1. Let val be OperationName().
 
         // 2. Assert: val is a normal completion.
-        Debug.Assert(completion.IsNormalCompletion());
+        Assert(completion.IsNormalCompletion(), "2. Assert: val is a normal completion.");
 
         // 3. Set val to val.[[Value]].
         return completion.Value;
@@ -160,7 +161,7 @@ internal static class CompletionHelper
         // 1. Let val be OperationName().
 
         // 2. Assert: val is a normal completion.
-        Debug.Assert(!abruptOr.IsAbruptCompletion());
+        Assert(!abruptOr.IsAbruptCompletion(), "2. Assert: val is a normal completion.");
 
         // 3. Set val to val.[[Value]].
         return abruptOr.Value;

--- a/JSS.Lib/Execution/DeclarativeEnvironment.cs
+++ b/JSS.Lib/Execution/DeclarativeEnvironment.cs
@@ -29,7 +29,7 @@ internal class DeclarativeEnvironment : Environment
     override public Completion CreateMutableBinding(VM _, string N, bool D)
     {
         // 1. Assert: envRec does not already have a binding for N.
-        Debug.Assert(!_identifierToBinding.ContainsKey(N));
+        Assert(!_identifierToBinding.ContainsKey(N), "1. Assert: envRec does not already have a binding for N.");
 
         // 2. Create a mutable binding in envRec for N and record that it is FIXME: uninitialized.
         // FIXME: If D is true, record that the newly created binding may be deleted by a subsequent DeleteBinding call.
@@ -43,7 +43,7 @@ internal class DeclarativeEnvironment : Environment
     override public Completion CreateImmutableBinding(VM _, string N, bool S)
     {
         // 1. Assert: envRec does not already have a binding for N.
-        Debug.Assert(!_identifierToBinding.ContainsKey(N));
+        Assert(!_identifierToBinding.ContainsKey(N), "1. Assert: envRec does not already have a binding for N.");
 
         // 2. Create an immutable binding in envRec for N and record that it is FIXME: uninitialized.
         // If S is true, record that the newly created binding is a strict binding.
@@ -125,7 +125,7 @@ internal class DeclarativeEnvironment : Environment
     override public Completion GetBindingValue(VM _, string N, bool S)
     {
         // 1. Assert: envRec has a binding for N.
-        Debug.Assert(_identifierToBinding.ContainsKey(N));
+        Assert(_identifierToBinding.ContainsKey(N), "1. Assert: envRec has a binding for N.");
 
         // FIXME: 2. If the binding for N in envRec is an uninitialized binding, throw a ReferenceError exception.
 
@@ -138,7 +138,7 @@ internal class DeclarativeEnvironment : Environment
     public override Completion DeleteBinding(string N)
     {
         // 1. Assert: envRec has a binding for N.
-        Debug.Assert(_identifierToBinding.ContainsKey(N));
+        Assert(_identifierToBinding.ContainsKey(N), "1. Assert: envRec has a binding for N.");
 
         // 2. If the binding for N in envRec cannot be deleted, return false.
 

--- a/JSS.Lib/Execution/FunctionEnvironment.cs
+++ b/JSS.Lib/Execution/FunctionEnvironment.cs
@@ -44,7 +44,7 @@ internal class FunctionEnvironment : DeclarativeEnvironment
     public Completion BindThisValue(VM vm, Value V)
     {
         // 1. Assert: envRec.[[ThisBindingStatus]] is not LEXICAL.
-        Debug.Assert(ThisBindingStatus != ThisBindingStatus.LEXICAL);
+        Assert(ThisBindingStatus != ThisBindingStatus.LEXICAL, "1. Assert: envRec.[[ThisBindingStatus]] is not LEXICAL.");
 
         // 2. If envRec.[[ThisBindingStatus]] is INITIALIZED, throw a ReferenceError exception.
         if (ThisBindingStatus == ThisBindingStatus.INITIALIZED)
@@ -73,7 +73,7 @@ internal class FunctionEnvironment : DeclarativeEnvironment
     override public Completion GetThisBinding(VM vm)
     {
         // 1. Assert: envRec.[[ThisBindingStatus]] is not LEXICAL.
-        Debug.Assert(ThisBindingStatus != ThisBindingStatus.LEXICAL);
+        Assert(ThisBindingStatus != ThisBindingStatus.LEXICAL, "1. Assert: envRec.[[ThisBindingStatus]] is not LEXICAL.");
 
         // 2. If envRec.[[ThisBindingStatus]] is UNINITIALIZED, throw a ReferenceError exception.
         if (ThisBindingStatus == ThisBindingStatus.UNINITIALIZED)

--- a/JSS.Lib/Execution/GlobalEnvironment.cs
+++ b/JSS.Lib/Execution/GlobalEnvironment.cs
@@ -81,7 +81,7 @@ internal sealed class GlobalEnvironment : Environment
         }
 
         // 3. Assert: If the binding exists, it must be in the Object Environment Record.
-        Debug.Assert(ObjectRecord.HasBinding(N));
+        Assert(ObjectRecord.HasBinding(N), "3. Assert: If the binding exists, it must be in the Object Environment Record.");
 
         // 4. Let ObjRec be envRec.[[ObjectRecord]].
         // 5. Return ? ObjRec.InitializeBinding(N, V).

--- a/JSS.Lib/Execution/Realm.cs
+++ b/JSS.Lib/Execution/Realm.cs
@@ -134,7 +134,7 @@ public sealed class Realm
         }
 
         // 2. Assert: globalObj is an Object.
-        Debug.Assert(globalObj.IsObject());
+        Assert(globalObj.IsObject(), "2. Assert: globalObj is an Object.");
 
         // 3. If thisValue is undefined, set thisValue to globalObj.
         if (thisValue.IsUndefined())

--- a/JSS.Lib/Execution/Script.cs
+++ b/JSS.Lib/Execution/Script.cs
@@ -64,7 +64,7 @@ public sealed class Script
         VM.PopExecutionContext();
 
         // 15. Assert: The execution context stack is not empty.
-        Debug.Assert(VM.HasExecutionContext());
+        Assert(VM.HasExecutionContext(), "15. Assert: The execution context stack is not empty.");
 
         // FIXME: 16. Resume the context that is now on the top of the execution context stack as the running execution context.
 
@@ -124,7 +124,7 @@ public sealed class Script
             if (d is not VarDeclaration or Identifier)
             {
                 // i. Assert: d is either a FunctionDeclaration, FIXME: a GeneratorDeclaration, an AsyncFunctionDeclaration, or an AsyncGeneratorDeclaration.
-                Debug.Assert(d is FunctionDeclaration);
+                Assert(d is FunctionDeclaration, "i. Assert: d is either a FunctionDeclaration, FIXME: a GeneratorDeclaration, an AsyncFunctionDeclaration, or an AsyncGeneratorDeclaration.");
 
                 // ii. NOTE: If there are multiple function declarations for the same name, the last declaration is used.
 

--- a/JSS.Lib/Execution/ScriptExecutionContext.cs
+++ b/JSS.Lib/Execution/ScriptExecutionContext.cs
@@ -76,7 +76,7 @@ internal sealed class ScriptExecutionContext : ExecutionContext
             var outer = env.OuterEnv;
 
             // d. Assert: outer is not null.
-            Debug.Assert(outer is not null);
+            Assert(outer is not null, "d. Assert: outer is not null.");
 
             // e. Set env to outer.
             env = outer;

--- a/JSS.Lib/Usings.cs
+++ b/JSS.Lib/Usings.cs
@@ -6,5 +6,7 @@ global using Object = JSS.Lib.AST.Values.Object;
 global using String = JSS.Lib.AST.Values.String; 
 global using ValueType = JSS.Lib.AST.Values.ValueType;
 
+global using static JSS.Lib.AssertionException;
+
 global using static JSS.Lib.Execution.CompletionHelper;
 global using static JSS.Lib.Execution.ThrowHelper;

--- a/JSS.Test262Runner/Test262Exceptions.cs
+++ b/JSS.Test262Runner/Test262Exceptions.cs
@@ -1,6 +1,5 @@
 ﻿using JSS.Common;
 using JSS.Lib.Execution;
-using System.Diagnostics;
 
 namespace JSS.Test262Runner;
 
@@ -14,7 +13,7 @@ internal class Test262Exception : Exception
 
     protected Test262Exception(VM vm, Completion abruptCompletion) : base(Print.CompletionToString(vm, abruptCompletion))
     {
-        Debug.Assert(abruptCompletion.IsAbruptCompletion());
+        throw new InvalidOperationException("Normal completion passed to a Test262Exception.");
     }
 }
 


### PR DESCRIPTION
Debug.Assert doesn't throw an exception and has semantics around trapping the debugger instead.

We now have our own "Assert" function that has the same functionality, but throws an exception with a message instead. This provides correct "crashes" as instead of continuing execution in an erroneous state, we throw immediately.