### PR TITLE
JSS-49 Implement converting Booleans, Numbers and Strings to Object in ToObject

### DIFF
--- a/JSS.Lib/AST/Values/BooleanObject.cs
+++ b/JSS.Lib/AST/Values/BooleanObject.cs
@@ -1,0 +1,16 @@
+﻿using JSS.Lib.Runtime;
+
+namespace JSS.Lib.AST.Values;
+
+// 20.3.4 Properties of Boolean Instances, https://tc39.es/ecma262/#sec-properties-of-boolean-instances
+internal sealed class BooleanObject : Object
+{
+    // FIXME: Boolean instances are ordinary objects that inherit properties from the Boolean prototype object.
+    public BooleanObject(ObjectPrototype prototype, Boolean value) : base(prototype)
+    {
+        BooleanData = value;
+    }
+
+    // [[BooleanData]]
+    public Boolean BooleanData { get; }
+}

--- a/JSS.Lib/AST/Values/NumberObject.cs
+++ b/JSS.Lib/AST/Values/NumberObject.cs
@@ -1,0 +1,16 @@
+﻿using JSS.Lib.Runtime;
+
+namespace JSS.Lib.AST.Values;
+
+// 21.1.4 Properties of Number Instances, https://tc39.es/ecma262/#sec-properties-of-number-instances
+internal sealed class NumberObject : Object
+{
+    // FIXME: Number instances are ordinary objects that inherit properties from the Number prototype object.
+    public NumberObject(ObjectPrototype prototype, Number value) : base(prototype)
+    {
+        NumberData = value;
+    }
+
+    // [[NumberData]]
+    public Number NumberData { get; }
+}

--- a/JSS.Lib/AST/Values/StringObject.cs
+++ b/JSS.Lib/AST/Values/StringObject.cs
@@ -1,0 +1,18 @@
+﻿using JSS.Lib.Runtime;
+
+namespace JSS.Lib.AST.Values;
+
+// 22.1.4 Properties of String Instances, https://tc39.es/ecma262/#sec-properties-of-string-instances
+internal sealed class StringObject : Object
+{
+    // FIXME: String instances are String exotic objects and have the internal methods specified for such objects.
+    // FIXME: String instances inherit properties from the String prototype object.
+    // FIXME: String instances have a "length" property, and a set of enumerable properties with integer-indexed names.
+    public StringObject(ObjectPrototype prototype, String value) : base(prototype)
+    {
+        StringData = value;
+    }
+
+    // [[StringData]]
+    public String StringData { get; }
+}

--- a/JSS.Lib/AST/Values/Value.cs
+++ b/JSS.Lib/AST/Values/Value.cs
@@ -608,6 +608,12 @@ public abstract class Value
             return new NumberObject(vm.ObjectPrototype, AsNumber());
         }
 
+        // String, Return a new String object whose [[StringData]] internal slot is set to argument.
+        if (IsString())
+        {
+            return new StringObject(vm.ObjectPrototype, AsString());
+        }
+
         // FIXME: Implement the rest of the conversions
 
         // Object, Return argument.

--- a/JSS.Lib/AST/Values/Value.cs
+++ b/JSS.Lib/AST/Values/Value.cs
@@ -602,6 +602,12 @@ public abstract class Value
             return new BooleanObject(vm.ObjectPrototype, AsBoolean());
         }
 
+        // Number, Return a new Number object whose [[NumberData]] internal slot is set to argument.
+        if (IsNumber())
+        {
+            return new NumberObject(vm.ObjectPrototype, AsNumber());
+        }
+
         // FIXME: Implement the rest of the conversions
 
         // Object, Return argument.

--- a/JSS.Lib/AST/Values/Value.cs
+++ b/JSS.Lib/AST/Values/Value.cs
@@ -596,6 +596,12 @@ public abstract class Value
             return ThrowTypeError(vm, RuntimeErrorType.UnableToConvertToObject, "null");
         }
 
+        // Boolean, Return a new Boolean object whose [[BooleanData]] internal slot is set to argument.
+        if (IsBoolean())
+        {
+            return new BooleanObject(vm.ObjectPrototype, AsBoolean());
+        }
+
         // FIXME: Implement the rest of the conversions
 
         // Object, Return argument.


### PR DESCRIPTION
We now support converting booleans, numbers and string to objects in the abstract operation "ToObject".

Previously we would fall-through to calling AsObject, which would fail an assertion, if the type of the value was any of the above mentioned types.

Test-262 Diff:
```
✅: +14 💥: -307 ❌: +293
```