### PR TITLE
JSS-55 Implement parsing and execution of property definitions inside of ObjectLiterals

### DIFF
--- a/JSS.Lib.UnitTests/ParserTests.cs
+++ b/JSS.Lib.UnitTests/ParserTests.cs
@@ -1666,6 +1666,130 @@ internal sealed class ParserTests
         objectLiteral.Should().NotBeNull();
     }
 
+    [TestCaseSource(nameof(expressionToExpectedTypeTestCases))]
+    public void Parse_ReturnsAssignment_WithObjectLiteralRSH_WithLiteralNameDefinition_WhenProvidingObjectLiteral_WithIdentifierDefinition(KeyValuePair<string, Type> expressionToExpectedType)
+    {
+        // Arrange
+        var expression = expressionToExpectedType.Key;
+        var expectedExpressionType = expressionToExpectedType.Value;
+        var parser = new Parser($"a = {{ a: {expression} }}");
+
+        // Act
+        var parsedProgram = ParseScript(parser);
+        var rootNodes = parsedProgram.ScriptCode;
+
+        // Assert
+        rootNodes.Should().HaveCount(1);
+
+        var expressionStatement = rootNodes[0] as ExpressionStatement;
+        expressionStatement.Should().NotBeNull();
+
+        var assignmentExpression = expressionStatement!.Expression as BasicAssignmentExpression;
+        assignmentExpression.Should().NotBeNull();
+
+        var objectLiteral = assignmentExpression!.Rhs as ObjectLiteral;
+        objectLiteral.Should().NotBeNull();
+
+        objectLiteral!.PropertyDefinitions.Should().HaveCount(1);
+
+        var propertyDefinition = objectLiteral.PropertyDefinitions[0] as PropertyNameDefinition;
+        propertyDefinition!.PropertyName.Should().BeOfType<LiteralPropertyName>();
+        propertyDefinition!.Expression.Should().BeOfType(expectedExpressionType);
+    }
+
+    [TestCaseSource(nameof(expressionToExpectedTypeTestCases))]
+    public void Parse_ReturnsAssignment_WithObjectLiteralRSH_WithLiteralNameDefinition_WhenProvidingObjectLiteral_WithStringLiteralDefinition(KeyValuePair<string, Type> expressionToExpectedType)
+    {
+        // Arrange
+        var expression = expressionToExpectedType.Key;
+        var expectedExpressionType = expressionToExpectedType.Value;
+        var parser = new Parser($"a = {{ \"a\": {expression} }}");
+
+        // Act
+        var parsedProgram = ParseScript(parser);
+        var rootNodes = parsedProgram.ScriptCode;
+
+        // Assert
+        rootNodes.Should().HaveCount(1);
+
+        var expressionStatement = rootNodes[0] as ExpressionStatement;
+        expressionStatement.Should().NotBeNull();
+
+        var assignmentExpression = expressionStatement!.Expression as BasicAssignmentExpression;
+        assignmentExpression.Should().NotBeNull();
+
+        var objectLiteral = assignmentExpression!.Rhs as ObjectLiteral;
+        objectLiteral.Should().NotBeNull();
+
+        objectLiteral!.PropertyDefinitions.Should().HaveCount(1);
+
+        var propertyDefinition = objectLiteral.PropertyDefinitions[0] as PropertyNameDefinition;
+        propertyDefinition!.PropertyName.Should().BeOfType<LiteralPropertyName>();
+        propertyDefinition!.Expression.Should().BeOfType(expectedExpressionType);
+    }
+
+    [TestCaseSource(nameof(expressionToExpectedTypeTestCases))]
+    public void Parse_ReturnsAssignment_WithObjectLiteralRSH_WithLiteralNameDefinition_WhenProvidingObjectLiteral_WithNumericLiteralDefinition(KeyValuePair<string, Type> expressionToExpectedType)
+    {
+        // Arrange
+        var expression = expressionToExpectedType.Key;
+        var expectedExpressionType = expressionToExpectedType.Value;
+        var parser = new Parser($"a = {{ 1: {expression} }}");
+
+        // Act
+        var parsedProgram = ParseScript(parser);
+        var rootNodes = parsedProgram.ScriptCode;
+
+        // Assert
+        rootNodes.Should().HaveCount(1);
+
+        var expressionStatement = rootNodes[0] as ExpressionStatement;
+        expressionStatement.Should().NotBeNull();
+
+        var assignmentExpression = expressionStatement!.Expression as BasicAssignmentExpression;
+        assignmentExpression.Should().NotBeNull();
+
+        var objectLiteral = assignmentExpression!.Rhs as ObjectLiteral;
+        objectLiteral.Should().NotBeNull();
+
+        objectLiteral!.PropertyDefinitions.Should().HaveCount(1);
+
+        var propertyDefinition = objectLiteral.PropertyDefinitions[0] as PropertyNameDefinition;
+        propertyDefinition!.PropertyName.Should().BeOfType<LiteralPropertyName>();
+        propertyDefinition!.Expression.Should().BeOfType(expectedExpressionType);
+    }
+
+    [TestCaseSource(nameof(expressionToExpectedTypeTestCases))]
+    public void Parse_ReturnsAssignment_WithObjectLiteralRSH_WithComputedNameDefinition_WhenProvidingObjectLiteral_WithExpression(KeyValuePair<string, Type> expressionToExpectedType)
+    {
+        // Arrange
+        var expression = expressionToExpectedType.Key;
+        var expectedExpressionType = expressionToExpectedType.Value;
+        var parser = new Parser($"a = {{ [{expression}]: {expression} }}");
+
+        // Act
+        var parsedProgram = ParseScript(parser);
+        var rootNodes = parsedProgram.ScriptCode;
+
+        // Assert
+        rootNodes.Should().HaveCount(1);
+
+        var expressionStatement = rootNodes[0] as ExpressionStatement;
+        expressionStatement.Should().NotBeNull();
+
+        var assignmentExpression = expressionStatement!.Expression as BasicAssignmentExpression;
+        assignmentExpression.Should().NotBeNull();
+
+        var objectLiteral = assignmentExpression!.Rhs as ObjectLiteral;
+        objectLiteral.Should().NotBeNull();
+
+        objectLiteral!.PropertyDefinitions.Should().HaveCount(1);
+
+        var propertyDefinition = objectLiteral.PropertyDefinitions[0] as PropertyNameDefinition;
+        propertyDefinition!.PropertyName.Should().BeOfType<ComputedPropertyName>();
+        propertyDefinition!.Expression.Should().BeOfType(expectedExpressionType);
+    }
+
     // Tests for SyntaxErrors
     static private readonly Dictionary<string, string> unexpectedTokenTestCases = new()
     {
@@ -1761,6 +1885,9 @@ internal sealed class ParserTests
         {"a ?", "}"},
         {"a ? b", "}"},
         {"a ? b :", "}"},
+        { "let a = { a:", "}"},
+        { "let a = { \"a\":", "}"},
+        { "let a = { 1:", "}"},
     };
 
     [TestCaseSource(nameof(unexpectedTokenTestCases))]
@@ -1873,6 +2000,9 @@ internal sealed class ParserTests
         "a ?",
         "a ? b",
         "a ? b :",
+        "let a = { a:",
+        "let a = { \"a\":",
+        "let a = { 1:",
     };
 
     [TestCaseSource(nameof(unexpectedEofTestCases))]

--- a/JSS.Lib/AST/ComputedPropertyName.cs
+++ b/JSS.Lib/AST/ComputedPropertyName.cs
@@ -1,0 +1,12 @@
+﻿namespace JSS.Lib.AST;
+
+// ComputedPropertyName, https://tc39.es/ecma262/#prod-ComputedPropertyName
+internal sealed class ComputedPropertyName : INode
+{
+    public ComputedPropertyName(IExpression expression)
+    {
+        Expression = expression;
+    }
+
+    public IExpression Expression { get; }
+}

--- a/JSS.Lib/AST/ComputedPropertyName.cs
+++ b/JSS.Lib/AST/ComputedPropertyName.cs
@@ -1,4 +1,6 @@
-﻿namespace JSS.Lib.AST;
+﻿using JSS.Lib.Execution;
+
+namespace JSS.Lib.AST;
 
 // ComputedPropertyName, https://tc39.es/ecma262/#prod-ComputedPropertyName
 internal sealed class ComputedPropertyName : INode
@@ -6,6 +8,21 @@ internal sealed class ComputedPropertyName : INode
     public ComputedPropertyName(IExpression expression)
     {
         Expression = expression;
+    }
+
+    // 13.2.5.4 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-object-initializer-runtime-semantics-evaluation
+    public override Completion Evaluate(VM vm)
+    {
+        // 1. Let exprValue be ? Evaluation of AssignmentExpression.
+        var exprValue = Expression.Evaluate(vm);
+        if (exprValue.IsAbruptCompletion()) return exprValue;
+
+        // 2. Let propName be ? GetValue(exprValue).
+        var propName = exprValue.Value.GetValue(vm);
+        if (propName.IsAbruptCompletion()) return propName;
+
+        // 3. Return ? ToPropertyKey(propName).
+        return propName.Value.ToPropertyKey(vm);
     }
 
     public IExpression Expression { get; }

--- a/JSS.Lib/AST/IPropertyDefinition.cs
+++ b/JSS.Lib/AST/IPropertyDefinition.cs
@@ -1,0 +1,10 @@
+﻿using JSS.Lib.Execution;
+
+namespace JSS.Lib.AST;
+
+// Represents the definition of a property that has the "PropertyDefinitionEvaluation" semantics, https://tc39.es/ecma262/#sec-runtime-semantics-propertydefinitionevaluation
+internal interface IPropertyDefinition
+{
+    // 13.2.5.5 Runtime Semantics: PropertyDefinitionEvaluation, https://tc39.es/ecma262/#sec-runtime-semantics-propertydefinitionevaluation
+    public Completion PropertyDefinitionEvaluation(VM vm, Object obj);
+}

--- a/JSS.Lib/AST/Literal/ObjectLiteral.cs
+++ b/JSS.Lib/AST/Literal/ObjectLiteral.cs
@@ -5,6 +5,11 @@ namespace JSS.Lib.AST.Literal;
 // 13.2.5 Object Initializer, https://tc39.es/ecma262/#sec-object-initializer
 internal class ObjectLiteral : IExpression
 {
+    public ObjectLiteral(List<INode> propertyDefinitionList)
+    {
+        PropertyDefinitions = propertyDefinitionList;
+    }
+
     // 13.2.5.4 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-object-initializer-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
@@ -12,4 +17,6 @@ internal class ObjectLiteral : IExpression
         // 1. Return OrdinaryObjectCreate(%Object.prototype%).
         return new Object(vm.ObjectPrototype);
     }
+
+    public IReadOnlyList<INode> PropertyDefinitions { get; }
 }

--- a/JSS.Lib/AST/Literal/ObjectLiteral.cs
+++ b/JSS.Lib/AST/Literal/ObjectLiteral.cs
@@ -1,11 +1,12 @@
-﻿using JSS.Lib.Execution;
+﻿using JSS.Lib.AST.Values;
+using JSS.Lib.Execution;
 
 namespace JSS.Lib.AST.Literal;
 
 // 13.2.5 Object Initializer, https://tc39.es/ecma262/#sec-object-initializer
 internal class ObjectLiteral : IExpression
 {
-    public ObjectLiteral(List<INode> propertyDefinitionList)
+    public ObjectLiteral(List<IPropertyDefinition> propertyDefinitionList)
     {
         PropertyDefinitions = propertyDefinitionList;
     }
@@ -13,10 +14,32 @@ internal class ObjectLiteral : IExpression
     // 13.2.5.4 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-object-initializer-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
-        // FIXME: Implement the rest of the evaluation when we parse property definitions
-        // 1. Return OrdinaryObjectCreate(%Object.prototype%).
-        return new Object(vm.ObjectPrototype);
+        // 1. Let obj be OrdinaryObjectCreate(%Object.prototype%).
+        var obj = new Object(vm.ObjectPrototype);
+
+        // 2. Perform ? PropertyDefinitionEvaluation of PropertyDefinitionList with argument obj.
+        var definitionResult = PropertyDefinitionEvaluation(vm, obj);
+        if (definitionResult.IsAbruptCompletion()) return definitionResult;
+
+        // 3. Return obj.
+        return obj;
     }
 
-    public IReadOnlyList<INode> PropertyDefinitions { get; }
+    // 13.2.5.5 Runtime Semantics: PropertyDefinitionEvaluation, https://tc39.es/ecma262/#sec-runtime-semantics-propertydefinitionevaluation
+    private Completion PropertyDefinitionEvaluation(VM vm, Object obj)
+    {
+        // 1. Perform ? PropertyDefinitionEvaluation of PropertyDefinitionList with argument object.
+        // 2. Perform ? PropertyDefinitionEvaluation of PropertyDefinition with argument object.
+        foreach (var propertyDefinition in PropertyDefinitions)
+        {
+            var definitionResult = propertyDefinition.PropertyDefinitionEvaluation(vm, obj);
+            if (definitionResult.IsAbruptCompletion()) return definitionResult;
+        }
+
+        // 3. Return UNUSED.
+        return Empty.The;
+    }
+
+
+    public IReadOnlyList<IPropertyDefinition> PropertyDefinitions { get; }
 }

--- a/JSS.Lib/AST/LiteralPropertyName.cs
+++ b/JSS.Lib/AST/LiteralPropertyName.cs
@@ -1,4 +1,8 @@
-﻿namespace JSS.Lib.AST;
+﻿using JSS.Lib.AST.Literal;
+using JSS.Lib.AST.Values;
+using JSS.Lib.Execution;
+
+namespace JSS.Lib.AST;
 
 // LiteralPropertyName, https://tc39.es/ecma262/#prod-LiteralPropertyName
 internal sealed class LiteralPropertyName : INode
@@ -6,6 +10,35 @@ internal sealed class LiteralPropertyName : INode
     public LiteralPropertyName(INode literal)
     {
         Literal = literal;
+    }
+
+    // 13.2.5.4 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-object-initializer-runtime-semantics-evaluation
+    public override Completion Evaluate(VM vm)
+    {
+        if (Literal is Identifier)
+        {
+            // 1. Return StringValue of IdentifierName.
+            var identifier = Literal as Identifier;
+            return identifier!.Name;
+        }
+        else if (Literal is StringLiteral)
+        {
+            // 1. Return the SV of StringLiteral.
+            var stringLiteral = Literal as StringLiteral;
+            return stringLiteral!.Value;
+        }
+        else if (Literal is NumericLiteral)
+        {
+            // 1. Let nbr be the NumericValue of NumericLiteral.
+            var numericLiteral = Literal as NumericLiteral;
+            var nbr = new Number(numericLiteral!.Value);
+
+            // 2. Return ! ToString(nbr).
+            return MUST(nbr.ToStringJS(vm));
+        }
+
+        Assert(false, $"{nameof(LiteralPropertyName)} created with invalid literal node");
+        return Empty.The;
     }
 
     public INode Literal { get; }

--- a/JSS.Lib/AST/LiteralPropertyName.cs
+++ b/JSS.Lib/AST/LiteralPropertyName.cs
@@ -1,0 +1,12 @@
+﻿namespace JSS.Lib.AST;
+
+// LiteralPropertyName, https://tc39.es/ecma262/#prod-LiteralPropertyName
+internal sealed class LiteralPropertyName : INode
+{
+    public LiteralPropertyName(INode literal)
+    {
+        Literal = literal;
+    }
+
+    public INode Literal { get; }
+}

--- a/JSS.Lib/AST/PropertyNameDefinition.cs
+++ b/JSS.Lib/AST/PropertyNameDefinition.cs
@@ -1,11 +1,51 @@
-﻿namespace JSS.Lib.AST;
+﻿using JSS.Lib.AST.Values;
+using JSS.Lib.Execution;
 
-internal sealed class PropertyNameDefinition : INode
+namespace JSS.Lib.AST;
+
+internal sealed class PropertyNameDefinition : IPropertyDefinition
 {
     public PropertyNameDefinition(INode propertyName, IExpression expression)
     {
         PropertyName = propertyName;
         Expression = expression;
+    }
+
+    // 13.2.5.5 Runtime Semantics: PropertyDefinitionEvaluation, https://tc39.es/ecma262/#sec-runtime-semantics-propertydefinitionevaluation
+    public Completion PropertyDefinitionEvaluation(VM vm, Object obj)
+    {
+        // 1. Let propKey be ? Evaluation of PropertyName.
+        var propKey = PropertyName.Evaluate(vm);
+        if (propKey.IsAbruptCompletion()) return propKey;
+
+        // FIXME: 2. If this PropertyDefinition is contained within a Script that is being evaluated for JSON.parse (see step 7 of JSON.parse), then
+        // FIXME: a. Let isProtoSetter be false.
+        // FIXME: 3. Else if propKey is "__proto__" and IsComputedPropertyKey of PropertyName is false, then
+        // FIXME: a. Let isProtoSetter be true.
+        // FIXME: 4. Else,
+        // FIXME: a. Let isProtoSetter be false.
+        // FIXME: 5. If IsAnonymousFunctionDefinition(AssignmentExpression) is true and isProtoSetter is false, then
+        // FIXME: a. Let propValue be ? NamedEvaluation of AssignmentExpression with argument propKey.
+        // 6. Else,
+        // a. Let exprValueRef be ? Evaluation of AssignmentExpression.
+        var exprValueRef = Expression.Evaluate(vm);
+        if (exprValueRef.IsAbruptCompletion()) return exprValueRef;
+
+        // b. Let propValue be ? GetValue(exprValueRef).
+        var propValue = exprValueRef.Value.GetValue(vm);
+        if (propValue.IsAbruptCompletion()) return propValue;
+
+        // FIXME: 7. If isProtoSetter is true, then
+        // FIXME: a. If propValue is an Object or propValue is null, then
+        // FIXME: i. Perform ! object.[[SetPrototypeOf]](propValue).
+        // FIXME: b. Return UNUSED.
+        // FIXME: 8. Assert: object is an ordinary, extensible object with no non-configurable properties.
+
+        // 9. Perform ! CreateDataPropertyOrThrow(object, propKey, propValue).
+        MUST(Object.CreateDataPropertyOrThrow(vm, obj, propKey.Value.AsString(), propValue.Value));
+
+        // 10. Return UNUSED.
+        return Empty.The;
     }
 
     public INode PropertyName { get; }

--- a/JSS.Lib/AST/PropertyNameDefinition.cs
+++ b/JSS.Lib/AST/PropertyNameDefinition.cs
@@ -1,0 +1,13 @@
+﻿namespace JSS.Lib.AST;
+
+internal sealed class PropertyNameDefinition : INode
+{
+    public PropertyNameDefinition(INode propertyName, IExpression expression)
+    {
+        PropertyName = propertyName;
+        Expression = expression;
+    }
+
+    public INode PropertyName { get; }
+    public IExpression Expression { get; }
+}

--- a/JSS.Lib/Parser.cs
+++ b/JSS.Lib/Parser.cs
@@ -1433,9 +1433,9 @@ public sealed class Parser
         return new ObjectLiteral(propertyDefinitionList);
     }
 
-    private List<INode> ParsePropertyDefinitionList()
+    private List<IPropertyDefinition> ParsePropertyDefinitionList()
     {
-        List<INode> propertyDefinitionList = new();
+        List<IPropertyDefinition> propertyDefinitionList = new();
 
         while (TryParsePropertyName(out var propertyName))
         {


### PR DESCRIPTION
We now implement parsing and execution of property definitions inside of ObjectLiterals.

This allows for the definition of properties inside of object literals instead of manually defining them one by one.

Example Code:
```js
// Instead of
var a = {}
a.b = 1
// We now support
var a = { b: 1 }
```