### PR TITLE
JSS-58 Search prototypes to find the name in GetErrorNameFromValue

### DIFF
--- a/JSS.Common/Print.cs
+++ b/JSS.Common/Print.cs
@@ -104,7 +104,8 @@ public sealed class Print
         if (!value.IsObject()) return "";
 
         var asObject = value.AsObject();
-        if (!asObject.DataProperties.TryGetValue("name", out var errorProperty)) return "";
+        var errorProperty = asObject.Get("name", asObject);
+        if (errorProperty.IsAbruptCompletion()) return "";
 
         var errorName = errorProperty.Value;
         if (!errorName.IsString()) return "";


### PR DESCRIPTION
We didn't go through prototypes in Print.GetErrorNameFromValue.

However, NativeErrors would have the name property in the NativeErrorPrototype NOT the actual NativeError object.