### PR TITLE
JSS-61 Create and automatically upload NuGet packages for JSS.Lib

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,6 +1,3 @@
-# This workflow will build a .NET project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
-
 name: Build and Test JSS
 
 on:
@@ -25,3 +22,6 @@ jobs:
       run: dotnet build --no-restore
     - name: Test
       run: dotnet test --no-build --verbosity normal
+    - name: Upload NuGet package
+      if: github.ref == 'refs/heads/master'
+      run: dotnet nuget push .\JSS.Lib\bin\Release\JSS*.nupkg -k ${{ secrets.JSS_NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json

--- a/JSS.Lib/JSS.Lib.csproj
+++ b/JSS.Lib/JSS.Lib.csproj
@@ -3,6 +3,20 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <Title>JavaScript Sharp</Title>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <Authors>PrestonTaylor</Authors>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryUrl>https://github.com/PrestonLTaylor/JSS/</RepositoryUrl>
+    <Copyright>2023-2024 - Preston Taylor</Copyright>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>JavaScript</PackageTags>
+    <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <Description>A JavaScript engine library for parsing and executing JavaScript scripts.</Description>
+    <Product>JSS</Product>
+    <PackageId>JSS</PackageId>
+    <PackageVersion>$([System.DateTime]::Now.ToString("yy.MM.dd.HHmmss"))</PackageVersion>
   </PropertyGroup>
 
 	<ItemGroup>
@@ -21,6 +35,17 @@
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
             <_Parameter1>JSS.Benchmarks</_Parameter1>
         </AssemblyAttribute>
+    </ItemGroup>
+
+    <ItemGroup>
+      <None Include="..\LICENSE">
+        <Pack>True</Pack>
+        <PackagePath>\</PackagePath>
+      </None>
+      <None Include="..\README.md">
+        <Pack>True</Pack>
+        <PackagePath>\</PackagePath>
+      </None>
     </ItemGroup>
 
     <ItemGroup>

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2023 Preston Taylor
+Copyright 2023-2024 Preston Taylor
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
We now create a NuGet package whenever we build JSS.Lib.

We also have a CI job for uploading the built NuGet package for JSS.Lib whenever we push to the master branch.