### PR TITLE
JSS-64 Implement VarDeclaresNames/Declarations for ForInStatements

### DIFF
--- a/JSS.Lib/AST/ForInStatement.cs
+++ b/JSS.Lib/AST/ForInStatement.cs
@@ -13,6 +13,32 @@ internal sealed class ForInStatement : INode
         IterationStatement = iterationStatement;
     }
 
+    // 8.2.6 Static Semantics: VarDeclaredNames, https://tc39.es/ecma262/#sec-static-semantics-vardeclarednames
+    public override List<string> VarDeclaredNames()
+    {
+        // 1. Let names1 be the BoundNames of ForBinding.
+        var names = Identifier.BoundNames();
+
+        // 2. Let names2 be the VarDeclaredNames of Statement.
+        names.AddRange(IterationStatement.VarDeclaredNames());
+
+        // 3. Return the list-concatenation of names1 and names2.
+        return names;
+    }
+
+    // 8.2.7 Static Semantics: VarScopedDeclarations, https://tc39.es/ecma262/#sec-static-semantics-varscopeddeclarations
+    public override List<INode> VarScopedDeclarations()
+    {
+        // 1. Let declarations1 be « ForBinding ».
+        var declarations = new List<INode>() { Identifier };
+
+        // 2. Let declarations2 be VarScopedDeclarations of Statement.
+        declarations.AddRange(IterationStatement.VarScopedDeclarations());
+
+        // 3. Return the list-concatenation of declarations1 and declarations2.
+        return declarations;
+    }
+
     // 14.7.5.5 Runtime Semantics: ForInOfLoopEvaluation, https://tc39.es/ecma262/#sec-runtime-semantics-forinofloopevaluation
     public override Completion Evaluate(VM vm)
     {

--- a/JSS.Lib/AST/Values/FunctionObject.cs
+++ b/JSS.Lib/AST/Values/FunctionObject.cs
@@ -426,7 +426,7 @@ internal sealed class FunctionObject : Object, ICallable, IConstructable
             var d = varDeclarations[i];
 
             // a. If d is neither a VariableDeclaration nor a ForBinding nor a BindingIdentifier, then
-            if (d is not VarDeclaration or Identifier)
+            if (d is not VarDeclaration and not Identifier)
             {
                 Assert(d is FunctionDeclaration, "i. Assert: d is either a FunctionDeclaration, a GeneratorDeclaration, an AsyncFunctionDeclaration, or an AsyncGeneratorDeclaration.");
 

--- a/JSS.Lib/Execution/Script.cs
+++ b/JSS.Lib/Execution/Script.cs
@@ -123,7 +123,7 @@ public sealed class Script
             var d = varDeclarations[i];
 
             // a. If d is not either a VariableDeclaration, a ForBinding, or a BindingIdentifier, then
-            if (d is not VarDeclaration or Identifier)
+            if (d is not VarDeclaration and not Identifier)
             {
                 // i. Assert: d is either a FunctionDeclaration, FIXME: a GeneratorDeclaration, an AsyncFunctionDeclaration, or an AsyncGeneratorDeclaration.
                 Assert(d is FunctionDeclaration, "i. Assert: d is either a FunctionDeclaration, FIXME: a GeneratorDeclaration, an AsyncFunctionDeclaration, or an AsyncGeneratorDeclaration.");


### PR DESCRIPTION
We now implement the missing VarDeclaresNames/Declarations for
ForInStatements. This would cause ReferenceErrors to be thrown in strict
mode as the var declaration would not be visible to the script.

```js
"use strict";

for (var x in this) {} // Would cause a ReferenceError, but no longer throws
```