### PR TITLE
JSS-65 Implement automatic semi-colon insertion

### DIFF
--- a/JSS.Lib.UnitTests/ParserTests.cs
+++ b/JSS.Lib.UnitTests/ParserTests.cs
@@ -232,6 +232,70 @@ internal sealed class ParserTests
         AssertThatSyntaxErrorMatchesExpected(parser, expectedException);
     }
 
+    [Test]
+    public void Parse_PreventsLineTerminator_BetweenExpressionAndPostfixUpdateOperator()
+    {
+        // Arrange
+        var parser = new Parser("a\n++");
+        var expectedException = ErrorHelper.CreateSyntaxError(ErrorType.UnexpectedEOF);
+
+        // Act
+
+        // Assert
+        AssertThatSyntaxErrorMatchesExpected(parser, expectedException);
+    }
+
+    [Test]
+    public void Parse_PreventsLineTerminator_BetweenContinueAndLabelIdentifier()
+    {
+        // Arrange
+        var parser = new Parser("continue\nidentifier");
+
+        // Act
+        var script = ParseScript(parser);
+
+        // Assert
+        script.ScriptCode.Should().HaveCount(2);
+
+        var continueStatement = script.ScriptCode[0] as ContinueStatement;
+        continueStatement.Should().NotBeNull();
+        continueStatement!.Label.Should().BeNull();
+    }
+
+    [Test]
+    public void Parse_PreventsLineTerminator_BetweenBreakAndLabelIdentifier()
+    {
+        // Arrange
+        var parser = new Parser("break\nidentifier");
+
+        // Act
+        var script = ParseScript(parser);
+
+        // Assert
+        script.ScriptCode.Should().HaveCount(2);
+
+        var breakStatement = script.ScriptCode[0] as BreakStatement;
+        breakStatement.Should().NotBeNull();
+        breakStatement!.Label.Should().BeNull();
+    }
+
+    [Test]
+    public void Parse_PreventsLineTerminator_BetweenReturnAndExpression()
+    {
+        // Arrange
+        var parser = new Parser("return\nidentifier");
+
+        // Act
+        var script = ParseScript(parser);
+
+        // Assert
+        script.ScriptCode.Should().HaveCount(2);
+
+        var returnStatement = script.ScriptCode[0] as ReturnStatement;
+        returnStatement.Should().NotBeNull();
+        returnStatement!.ReturnExpression.Should().BeNull();
+    }
+
     static private readonly Dictionary<string, Type> expressionToExpectedTypeTestCases = new()
     {
         { "1 || 2", typeof(LogicalOrExpression) },

--- a/JSS.Lib/Parser.cs
+++ b/JSS.Lib/Parser.cs
@@ -916,7 +916,8 @@ public sealed class Parser
         }
 
         // NOTE: If there is no postfix update operator, then the inner expression is the fully parsed expression
-        if (!IsUpdateOperator())
+        // NOTE: No line terminators are allowed between an expression and postfix update operator
+        if (_consumer.CanConsume(-1) && _consumer.IsLineTerminator(-1) || !IsUpdateOperator())
         {
             parsedExpression = innerExpression;
             return true;
@@ -1938,7 +1939,7 @@ public sealed class Parser
         _consumer.ConsumeTokenOfType(TokenType.Continue);
 
         Identifier? label = null;
-        if (IsIdentifier())
+        if (!_consumer.IsLineTerminator() && IsIdentifier())
         {
             label = ParseIdentifier();
         }
@@ -1959,7 +1960,7 @@ public sealed class Parser
         _consumer.ConsumeTokenOfType(TokenType.Break);
 
         Identifier? label = null;
-        if (IsIdentifier())
+        if (!_consumer.IsLineTerminator() && IsIdentifier())
         {
             label = ParseIdentifier();
         }
@@ -1979,9 +1980,8 @@ public sealed class Parser
     {
         _consumer.ConsumeTokenOfType(TokenType.Return);
 
-        if (_consumer.IsLineTerminator()) return new ReturnStatement(null);
-
-        TryParseExpression(out IExpression? returnExpression);
+        IExpression? returnExpression = null;
+        if (!_consumer.IsLineTerminator()) TryParseExpression(out returnExpression);
 
         ParseSemicolon();
 

--- a/JSS.Lib/TokenConsumer.cs
+++ b/JSS.Lib/TokenConsumer.cs
@@ -39,10 +39,10 @@ internal sealed class TokenConsumer
         return Consume();
     }
 
-    public bool IsLineTerminator()
+    public bool IsLineTerminator(int offset = 0)
     {
         if (!CanConsume()) return false;
-        return _toConsume[Index].type == TokenType.LineTerminator;
+        return _toConsume[Index + offset].type == TokenType.LineTerminator;
     }
 
     public void IgnoreLineTerminators()


### PR DESCRIPTION
We now handle the rules for automatic semicolon insertion.
We parse semi-colons as being there if there is a line terminator, a }, the last ) of a
do-while loop or an end of file is found.

Example Code:
```js
// let a let a would throw if ran as-is.
let a
let b // Works even if there are no semi-colons
```