### PR TITLE
JSS-66 Implement labelled evaluate for breakable statements

### DIFF
--- a/JSS.Lib.UnitTests/ASTTests.cs
+++ b/JSS.Lib.UnitTests/ASTTests.cs
@@ -214,7 +214,7 @@ internal sealed class ASTTests
         CreateNormalDoWhileTestCase("false", "1", 1),
         CreateNormalDoWhileTestCase("false", EscapeString("a"), "a"),
         CreateNormalDoWhileTestCase("false", "continue", Undefined.The),
-        CreateBreakDoWhileTestCase("false", "break", Undefined.The),
+        CreateNormalDoWhileTestCase("false", "break", Undefined.The),
         CreateReturnDoWhileTestCase("false", "return null", Null.The),
         CreateThrowDoWhileTestCase("false", "throw null", Null.The),
 
@@ -556,11 +556,6 @@ internal sealed class ASTTests
     static private object[] CreateNormalDoWhileTestCase(string expression, string statement, Value expected)
     {
         return new object[] { $"do {{ {statement} }} while ({expression})", Completion.NormalCompletion(expected) };
-    }
-
-    static private object[] CreateBreakDoWhileTestCase(string expression, string statement, Value expected)
-    {
-        return new object[] { $"do {{ {statement} }} while ({expression})", Completion.BreakCompletion(expected, "") };
     }
 
     static private object[] CreateReturnDoWhileTestCase(string expression, string statement, Value expected)

--- a/JSS.Lib/AST/DoWhileStatement.cs
+++ b/JSS.Lib/AST/DoWhileStatement.cs
@@ -4,7 +4,7 @@ using JSS.Lib.Execution;
 namespace JSS.Lib.AST;
 
 // 14.7.2 The do-while Statement, https://tc39.es/ecma262/#sec-do-while-statement
-internal sealed class DoWhileStatement : INode
+internal sealed class DoWhileStatement : INode, IBreakableStatement
 {
     public DoWhileStatement(IExpression whileExpression, INode iterationStatement)
     {
@@ -27,7 +27,7 @@ internal sealed class DoWhileStatement : INode
     }
 
     // 14.7.2.2 Runtime Semantics: DoWhileLoopEvaluation, https://tc39.es/ecma262/#sec-runtime-semantics-dowhileloopevaluation
-    override public Completion Evaluate(VM vm)
+    public Completion EvaluateFromLabelled(VM vm)
     {
         // 1. Let V be undefined.
         var V = (Value)Undefined.The;
@@ -65,6 +65,15 @@ internal sealed class DoWhileStatement : INode
                 return V;
             }
         }
+    }
+
+    // 14.1.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-statement-semantics-runtime-semantics-evaluation
+    public override Completion Evaluate(VM vm)
+    {
+        // FIXME: 1. Let newLabelSet be a new empty List.
+
+        // 2. Return ? LabelledEvaluation of this BreakableStatement with argument newLabelSet.
+        return LabelledStatement.LabelledBreakableEvaluation(vm, this);
     }
 
     public IExpression WhileExpression { get; }

--- a/JSS.Lib/AST/ForInStatement.cs
+++ b/JSS.Lib/AST/ForInStatement.cs
@@ -4,7 +4,7 @@ using JSS.Lib.Execution;
 namespace JSS.Lib.AST;
 
 // 14.7.5 The for-in, for-of, and for-await-of Statements, https://tc39.es/ecma262/#sec-for-in-and-for-of-statements
-internal sealed class ForInStatement : INode
+internal sealed class ForInStatement : INode, IBreakableStatement
 {
     public ForInStatement(Identifier identifier, IExpression expression, INode iterationStatement)
     {
@@ -40,7 +40,7 @@ internal sealed class ForInStatement : INode
     }
 
     // 14.7.5.5 Runtime Semantics: ForInOfLoopEvaluation, https://tc39.es/ecma262/#sec-runtime-semantics-forinofloopevaluation
-    public override Completion Evaluate(VM vm)
+    public Completion EvaluateFromLabelled(VM vm)
     {
         // 1. Let keyResult be ? ForIn/OfHeadEvaluation(« », Expression, ENUMERATE).
         var keyResult = ForInOfHeadEvaluation(vm);
@@ -152,6 +152,15 @@ internal sealed class ForInStatement : INode
         // 1. Return ? UpdateEmpty(result, V).
         result!.UpdateEmpty(V);
         return result;
+    }
+
+    // 14.1.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-statement-semantics-runtime-semantics-evaluation
+    public override Completion Evaluate(VM vm)
+    {
+        // FIXME: 1. Let newLabelSet be a new empty List.
+
+        // 2. Return ? LabelledEvaluation of this BreakableStatement with argument newLabelSet.
+        return LabelledStatement.LabelledBreakableEvaluation(vm, this);
     }
 
     public Identifier Identifier { get; }

--- a/JSS.Lib/AST/ForStatement.cs
+++ b/JSS.Lib/AST/ForStatement.cs
@@ -4,7 +4,7 @@ using JSS.Lib.Execution;
 namespace JSS.Lib.AST;
 
 // 14.7.4 The for Statement, https://tc39.es/ecma262/#sec-for-statement
-internal sealed class ForStatement : INode
+internal sealed class ForStatement : INode, IBreakableStatement
 {
     public ForStatement(INode? initializationExpression, INode? testExpression, INode? incrementExpression, INode iterationStatement)
     {
@@ -49,7 +49,7 @@ internal sealed class ForStatement : INode
     }
 
     // 14.7.4.2 Runtime Semantics: ForLoopEvaluation, https://tc39.es/ecma262/#sec-runtime-semantics-forloopevaluation
-    override public Completion Evaluate(VM vm)
+    public Completion EvaluateFromLabelled(VM vm)
     {
         if (InitializationExpression is VarStatement)
         {
@@ -161,6 +161,15 @@ internal sealed class ForStatement : INode
                 if (incValue.IsAbruptCompletion()) return incValue;
             }
         }
+    }
+
+    // 14.1.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-statement-semantics-runtime-semantics-evaluation
+    public override Completion Evaluate(VM vm)
+    {
+        // FIXME: 1. Let newLabelSet be a new empty List.
+
+        // 2. Return ? LabelledEvaluation of this BreakableStatement with argument newLabelSet.
+        return LabelledStatement.LabelledBreakableEvaluation(vm, this);
     }
 
     public INode? InitializationExpression { get; }

--- a/JSS.Lib/AST/IBreakableStatement.cs
+++ b/JSS.Lib/AST/IBreakableStatement.cs
@@ -1,0 +1,8 @@
+﻿using JSS.Lib.Execution;
+
+namespace JSS.Lib.AST;
+
+internal interface IBreakableStatement
+{
+    public Completion EvaluateFromLabelled(VM vm);
+}

--- a/JSS.Lib/AST/LabelledStatement.cs
+++ b/JSS.Lib/AST/LabelledStatement.cs
@@ -1,0 +1,31 @@
+﻿using JSS.Lib.AST.Values;
+using JSS.Lib.Execution;
+
+namespace JSS.Lib.AST;
+
+// FIXME: Parse and evaluate LabelledStatements
+internal class LabelledStatement
+{
+    // 14.13.4 Runtime Semantics: LabelledEvaluation, https://tc39.es/ecma262/#sec-runtime-semantics-labelledevaluation
+    static public Completion LabelledBreakableEvaluation(VM vm, IBreakableStatement breakableStatement)
+    {
+        // 1. Let stmtResult be Completion(LoopEvaluation of IterationStatement FIXME: with argument labelSet)/Completion(Evaluation of SwitchStatement).
+        var stmtResult = breakableStatement.EvaluateFromLabelled(vm);
+
+        // 2. If stmtResult is a break completion, then
+        if (stmtResult.IsBreakCompletion())
+        {
+            // a. If stmtResult.[[Target]] is EMPTY, then
+            if (stmtResult.Target.Length == 0)
+            {
+                // i. If stmtResult.[[Value]] is EMPTY, set stmtResult to NormalCompletion(undefined).
+                if (stmtResult.IsValueEmpty()) stmtResult = Undefined.The;
+                // ii. Else, set stmtResult to NormalCompletion(stmtResult.[[Value]]).
+                else stmtResult = stmtResult.Value;
+            }
+        }
+
+        // 3. Return ? stmtResult.
+        return stmtResult;
+    }
+}

--- a/JSS.Lib/AST/SwitchStatement.cs
+++ b/JSS.Lib/AST/SwitchStatement.cs
@@ -98,7 +98,7 @@ internal readonly struct DefaultBlock
 }
 
 // 14.12 The switch Statement, https://tc39.es/ecma262/#sec-switch-statement
-internal sealed class SwitchStatement : INode
+internal sealed class SwitchStatement : INode, IBreakableStatement
 {
     public SwitchStatement(IExpression switchExpression, List<CaseBlock> firstCaseBlocks, List<CaseBlock> secondCaseBlocks, DefaultBlock? defaultCase)
     {
@@ -439,7 +439,7 @@ internal sealed class SwitchStatement : INode
     }
 
     // 14.12.4 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-switch-statement-runtime-semantics-evaluation
-    public override Completion Evaluate(VM vm)
+    public Completion EvaluateFromLabelled(VM vm)
     {
         // 1. Let exprRef be ? Evaluation of Expression.
         var exprRef = SwitchExpression.Evaluate(vm);
@@ -468,12 +468,17 @@ internal sealed class SwitchStatement : INode
         // 8. Set the running execution context's LexicalEnvironment to oldEnv.
         executionContext.LexicalEnvironment = oldEnv;
 
-        // FIXME/NOTE: I'm not sure if this is a spec bug (probably not) or a bug in our code, but if we have a break completion here,
-        // we'll return the break completion and not execute anything else.
-        if (R.IsBreakCompletion()) R = R.Value;
-
         // 9. Return R.
         return R;
+    }
+
+    // 14.1.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-statement-semantics-runtime-semantics-evaluation
+    public override Completion Evaluate(VM vm)
+    {
+        // FIXME: 1. Let newLabelSet be a new empty List.
+
+        // 2. Return ? LabelledEvaluation of this BreakableStatement with argument newLabelSet.
+        return LabelledStatement.LabelledBreakableEvaluation(vm, this);
     }
 
     public IExpression SwitchExpression { get; }

--- a/JSS.Lib/AST/WhileStatement.cs
+++ b/JSS.Lib/AST/WhileStatement.cs
@@ -5,7 +5,7 @@ using JSS.Lib.Execution;
 namespace JSS.Lib.AST;
 
 // 14.7.3 The while Statement, https://tc39.es/ecma262/#sec-while-statement
-internal sealed class WhileStatement : INode
+internal sealed class WhileStatement : INode, IBreakableStatement
 {
     public WhileStatement(IExpression whileExpression, INode iterationStatement)
     {
@@ -28,7 +28,7 @@ internal sealed class WhileStatement : INode
     }
 
     // 14.7.3.2 Runtime Semantics: WhileLoopEvaluation, https://tc39.es/ecma262/#sec-runtime-semantics-whileloopevaluation
-    override public Completion Evaluate(VM vm)
+    public Completion EvaluateFromLabelled(VM vm)
     {
         // 1.Let V be undefined.
         var V = (Value)Undefined.The;
@@ -66,6 +66,15 @@ internal sealed class WhileStatement : INode
                 V = stmtResult.Value;
             }
         }
+    }
+
+    // 14.1.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-statement-semantics-runtime-semantics-evaluation
+    public override Completion Evaluate(VM vm)
+    {
+        // FIXME: 1. Let newLabelSet be a new empty List.
+
+        // 2. Return ? LabelledEvaluation of this BreakableStatement with argument newLabelSet.
+        return LabelledStatement.LabelledBreakableEvaluation(vm, this);
     }
 
     public IExpression WhileExpression { get; }


### PR DESCRIPTION
We now properly handle break completions inside of loops. We were skipping the labelled evaluation of breakable statements as required in the spec.

However, every breakable statement is now an IBreakableStatement that is to be evalauted in LabelledEvaluation.

Example Code:
```js
for (;;) { break; } // Now returns undefined as a normal completion
```