### PR TITLE
JSS-67 Implement parsing and execution of labelled statements

### DIFF
--- a/JSS.Lib.UnitTests/AbstractOperationTests.cs
+++ b/JSS.Lib.UnitTests/AbstractOperationTests.cs
@@ -331,21 +331,24 @@ internal sealed class AbstractOperationTests
 
     static private readonly object[] loopContinuesValueToExpectedResultTestCases =
     {
-        new object[] { Completion.NormalCompletion(Undefined.The), true },
-        new object[] { Completion.ThrowCompletion(Undefined.The), false },
-        new object[] { Completion.BreakCompletion(Undefined.The, ""), false },
-        new object[] { Completion.ReturnCompletion(Undefined.The), false },
-        new object[] { Completion.ContinueCompletion(Undefined.The, ""), true },
+        new object[] { Completion.NormalCompletion(Undefined.The), true, new List<string>() },
+        new object[] { Completion.ThrowCompletion(Undefined.The), false, new List<string>() },
+        new object[] { Completion.BreakCompletion(Undefined.The, ""), false, new List<string>() },
+        new object[] { Completion.ReturnCompletion(Undefined.The), false, new List<string>() },
+        new object[] { Completion.ContinueCompletion(Undefined.The, ""), true, new List<string>() },
+        new object[] { Completion.BreakCompletion(Undefined.The, "label"), false, new List<string>() { "label" } },
+        new object[] { Completion.ContinueCompletion(Undefined.The, "label"), true, new List<string>() { "label" } },
+        new object[] { Completion.ContinueCompletion(Undefined.The, "label"), false, new List<string>() { "notlabel" } },
     };
 
     [TestCaseSource(nameof(loopContinuesValueToExpectedResultTestCases))]
-    public void LoopContinues_ReturnsExpectedBoolean_WhenProvidedCompletion(Completion completion, bool expectedResult)
+    public void LoopContinues_ReturnsExpectedBoolean_WhenProvidedCompletion(Completion completion, bool expectedResult, List<string> labelSet)
     {
         // Arrange
         var expectedValue = new Boolean(expectedResult);
 
         // Act
-        var result = completion.LoopContinues();
+        var result = completion.LoopContinues(labelSet);
 
         // Assert
         result.Should().Be(expectedValue);

--- a/JSS.Lib/AST/DoWhileStatement.cs
+++ b/JSS.Lib/AST/DoWhileStatement.cs
@@ -4,7 +4,7 @@ using JSS.Lib.Execution;
 namespace JSS.Lib.AST;
 
 // 14.7.2 The do-while Statement, https://tc39.es/ecma262/#sec-do-while-statement
-internal sealed class DoWhileStatement : INode, IBreakableStatement
+internal sealed class DoWhileStatement : IIterationStatement
 {
     public DoWhileStatement(IExpression whileExpression, INode iterationStatement)
     {
@@ -27,7 +27,7 @@ internal sealed class DoWhileStatement : INode, IBreakableStatement
     }
 
     // 14.7.2.2 Runtime Semantics: DoWhileLoopEvaluation, https://tc39.es/ecma262/#sec-runtime-semantics-dowhileloopevaluation
-    public Completion EvaluateFromLabelled(VM vm)
+    public override Completion LoopEvaluation(VM vm, List<string> labelSet)
     {
         // 1. Let V be undefined.
         var V = (Value)Undefined.The;
@@ -39,7 +39,7 @@ internal sealed class DoWhileStatement : INode, IBreakableStatement
             var stmtResult = IterationStatement.Evaluate(vm);
 
             // b. If LoopContinues(stmtResult, labelSet) is false, return ? UpdateEmpty(stmtResult, V).
-            if (!stmtResult.LoopContinues().Value)
+            if (!stmtResult.LoopContinues(labelSet))
             {
                 stmtResult.UpdateEmpty(V);
                 return stmtResult;
@@ -65,15 +65,6 @@ internal sealed class DoWhileStatement : INode, IBreakableStatement
                 return V;
             }
         }
-    }
-
-    // 14.1.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-statement-semantics-runtime-semantics-evaluation
-    public override Completion Evaluate(VM vm)
-    {
-        // FIXME: 1. Let newLabelSet be a new empty List.
-
-        // 2. Return ? LabelledEvaluation of this BreakableStatement with argument newLabelSet.
-        return LabelledStatement.LabelledBreakableEvaluation(vm, this);
     }
 
     public IExpression WhileExpression { get; }

--- a/JSS.Lib/AST/IBreakableStatement.cs
+++ b/JSS.Lib/AST/IBreakableStatement.cs
@@ -1,8 +1,0 @@
-﻿using JSS.Lib.Execution;
-
-namespace JSS.Lib.AST;
-
-internal interface IBreakableStatement
-{
-    public Completion EvaluateFromLabelled(VM vm);
-}

--- a/JSS.Lib/AST/IIterationStatement.cs
+++ b/JSS.Lib/AST/IIterationStatement.cs
@@ -1,0 +1,40 @@
+﻿using JSS.Lib.AST.Values;
+using JSS.Lib.Execution;
+
+namespace JSS.Lib.AST;
+
+internal abstract class IIterationStatement : INode
+{
+    // 14.1.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-statement-semantics-runtime-semantics-evaluation
+    public override Completion Evaluate(VM vm)
+    {
+        // 1. Let newLabelSet be a new empty List.
+        // 2. Return ? LabelledEvaluation of this BreakableStatement with argument newLabelSet.
+        return LabelledEvaluation(vm, new());
+    }
+
+    // 14.13.4 Runtime Semantics: LabelledEvaluation, https://tc39.es/ecma262/#sec-runtime-semantics-labelledevaluation
+    public Completion LabelledEvaluation(VM vm, List<string> labelSet)
+    {
+        // 1. Let stmtResult be Completion(LoopEvaluation of IterationStatement with argument labelSet).
+        var stmtResult = LoopEvaluation(vm, labelSet);
+
+        // 2. If stmtResult is a break completion, then
+        if (stmtResult.IsBreakCompletion())
+        {
+            // a. If stmtResult.[[Target]] is EMPTY, then
+            if (stmtResult.Target.Length == 0)
+            {
+                // i. If stmtResult.[[Value]] is EMPTY, set stmtResult to NormalCompletion(undefined).
+                if (stmtResult.IsValueEmpty()) stmtResult = Undefined.The;
+                // ii. Else, set stmtResult to NormalCompletion(stmtResult.[[Value]]).
+                else stmtResult = stmtResult.Value;
+            }
+        }
+
+        // 3. Return ? stmtResult.
+        return stmtResult;
+    }
+
+    abstract public Completion LoopEvaluation(VM vm, List<string> labelSet);
+}

--- a/JSS.Lib/AST/LabelledStatement.cs
+++ b/JSS.Lib/AST/LabelledStatement.cs
@@ -4,8 +4,14 @@ using JSS.Lib.Execution;
 namespace JSS.Lib.AST;
 
 // FIXME: Parse and evaluate LabelledStatements
-internal class LabelledStatement
+internal class LabelledStatement : INode
 {
+    public LabelledStatement(Identifier identifier, INode labelledItem)
+    {
+        Identifier = identifier;
+        LabelledItem = labelledItem;
+    }
+
     // 14.13.4 Runtime Semantics: LabelledEvaluation, https://tc39.es/ecma262/#sec-runtime-semantics-labelledevaluation
     static public Completion LabelledBreakableEvaluation(VM vm, IBreakableStatement breakableStatement)
     {
@@ -28,4 +34,7 @@ internal class LabelledStatement
         // 3. Return ? stmtResult.
         return stmtResult;
     }
+
+    public Identifier Identifier { get; }
+    public INode LabelledItem { get; }
 }

--- a/JSS.Lib/AST/WhileStatement.cs
+++ b/JSS.Lib/AST/WhileStatement.cs
@@ -5,7 +5,7 @@ using JSS.Lib.Execution;
 namespace JSS.Lib.AST;
 
 // 14.7.3 The while Statement, https://tc39.es/ecma262/#sec-while-statement
-internal sealed class WhileStatement : INode, IBreakableStatement
+internal sealed class WhileStatement : IIterationStatement
 {
     public WhileStatement(IExpression whileExpression, INode iterationStatement)
     {
@@ -28,7 +28,7 @@ internal sealed class WhileStatement : INode, IBreakableStatement
     }
 
     // 14.7.3.2 Runtime Semantics: WhileLoopEvaluation, https://tc39.es/ecma262/#sec-runtime-semantics-whileloopevaluation
-    public Completion EvaluateFromLabelled(VM vm)
+    public override Completion LoopEvaluation(VM vm, List<string> labelSet)
     {
         // 1.Let V be undefined.
         var V = (Value)Undefined.The;
@@ -54,7 +54,7 @@ internal sealed class WhileStatement : INode, IBreakableStatement
             var stmtResult = IterationStatement.Evaluate(vm);
 
             // e. If LoopContinues(stmtResult, labelSet) is false, return ? UpdateEmpty(stmtResult, V).
-            if (!stmtResult.LoopContinues().Value)
+            if (!stmtResult.LoopContinues(labelSet))
             {
                 stmtResult.UpdateEmpty(V);
                 return stmtResult;
@@ -66,15 +66,6 @@ internal sealed class WhileStatement : INode, IBreakableStatement
                 V = stmtResult.Value;
             }
         }
-    }
-
-    // 14.1.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-statement-semantics-runtime-semantics-evaluation
-    public override Completion Evaluate(VM vm)
-    {
-        // FIXME: 1. Let newLabelSet be a new empty List.
-
-        // 2. Return ? LabelledEvaluation of this BreakableStatement with argument newLabelSet.
-        return LabelledStatement.LabelledBreakableEvaluation(vm, this);
     }
 
     public IExpression WhileExpression { get; }

--- a/JSS.Lib/Execution/Completion.cs
+++ b/JSS.Lib/Execution/Completion.cs
@@ -99,8 +99,8 @@ public sealed class Completion
         Value = value;
     }
 
-    // 14.7.1.1 LoopContinues ( completion, FIXME: labelSet ), https://tc39.es/ecma262/#sec-loopcontinues
-    public Boolean LoopContinues()
+    // 14.7.1.1 LoopContinues ( completion, labelSet ), https://tc39.es/ecma262/#sec-loopcontinues
+    public Boolean LoopContinues(List<string> labelSet)
     {
         // 1. If completion.[[Type]] is NORMAL, return true.
         if (IsNormalCompletion())
@@ -120,7 +120,9 @@ public sealed class Completion
             return true;
         }
 
-        // FIXME: 4. If labelSet contains completion.[[Target]], return true.
+        // FIXME: Maybe use a hash-set and do some benchmarks
+        // 4. If labelSet contains completion.[[Target]], return true.
+        if (labelSet.Contains(Target)) return true;
 
         // 5. Return false.
         return false;

--- a/JSS.Lib/Parser.cs
+++ b/JSS.Lib/Parser.cs
@@ -111,6 +111,11 @@ public sealed class Parser
             statement = ParseVarStatement();
             return true;
         }
+        if (IsLabelledStatement())
+        {
+            statement = ParseLabelledStatement();
+            return true;
+        }
         if (IsEmptyStatement())
         {
             statement = ParseEmptyStatement();
@@ -2071,6 +2076,29 @@ public sealed class Parser
                 _ => true,
             };
         });
+    }
+
+    // 14.13 Labelled Statements, https://tc39.es/ecma262/#sec-labelled-statements
+    private bool IsLabelledStatement()
+    {
+        return _consumer.IsTokenOfType(TokenType.Identifier) && _consumer.IsTokenOfType(TokenType.Colon, 1);
+    }
+
+    private LabelledStatement ParseLabelledStatement()
+    {
+        var identifier = ParseIdentifier();
+
+        _consumer.ConsumeTokenOfType(TokenType.Colon);
+
+        var labelledItem = ParseLabelledItem();
+
+        return new LabelledStatement(identifier, labelledItem);
+    }
+
+    private INode ParseLabelledItem()
+    {
+        if (IsFunctionDeclaration()) return ThrowUnexpectedTokenSyntaxError<INode>()!;
+        return ParseStatement();
     }
 
     // 14.14 The throw Statement, https://tc39.es/ecma262/#sec-throw-statement

--- a/JSS.Lib/TokenConsumer.cs
+++ b/JSS.Lib/TokenConsumer.cs
@@ -25,10 +25,10 @@ internal sealed class TokenConsumer
         return _toConsume[Index + offset];
     }
 
-    public bool IsTokenOfType(TokenType type)
+    public bool IsTokenOfType(TokenType type, int offset = 0)
     {
         IgnoreLineTerminators();
-        return CanConsume() && Peek().type == type;
+        return CanConsume(offset) && Peek(offset).type == type;
     }
 
     public Token ConsumeTokenOfType(TokenType type)


### PR DESCRIPTION
We now support parsing and execution of labelled statements. We also
implement the support for labelled statements inside of loops and switch
statements as well.

Example Code:
```js
loop1: for (var i = 0; i < 10; ++i) { break loop1; i } // Always returns undefined.
```