### PR TITLE
JSS-73 Define the name and length properties of builtin functions

### DIFF
--- a/JSS.Lib/AST/FunctionDeclaration.cs
+++ b/JSS.Lib/AST/FunctionDeclaration.cs
@@ -36,7 +36,7 @@ internal sealed class FunctionDeclaration : Declaration
         var F = FunctionObject.OrdinaryFunctionCreate(vm.FunctionPrototype, Parameters, Body, LexicalThisMode.NON_LEXICAL_THIS, env, vm.IsStrict || IsStrict);
 
         // 4. Perform SetFunctionName(F, name).
-        F.SetFunctionName(vm, Identifier);
+        FunctionObject.SetFunctionName(vm, F, Identifier);
 
         // 5. Perform MakeConstructor(F).
         F.MakeConstructor(vm);

--- a/JSS.Lib/AST/FunctionExpression.cs
+++ b/JSS.Lib/AST/FunctionExpression.cs
@@ -46,7 +46,7 @@ internal sealed class FunctionExpression : IExpression
         var closure = FunctionObject.OrdinaryFunctionCreate(vm.FunctionPrototype, Parameters, Body, LexicalThisMode.NON_LEXICAL_THIS, env!, vm.IsStrict || IsStrict);
 
         // 6. Perform SetFunctionName(closure, name).
-        closure.SetFunctionName(vm, name);
+        FunctionObject.SetFunctionName(vm, closure, name);
 
         // 7. Perform MakeConstructor(closure).
         closure.MakeConstructor(vm);
@@ -78,7 +78,7 @@ internal sealed class FunctionExpression : IExpression
         var closure = FunctionObject.OrdinaryFunctionCreate(vm.FunctionPrototype, Parameters, Body, LexicalThisMode.NON_LEXICAL_THIS, funcEnv, vm.IsStrict || IsStrict);
 
         // 9. Perform SetFunctionName(closure, name).
-        closure.SetFunctionName(vm, name);
+        FunctionObject.SetFunctionName(vm, closure, name);
 
         // 10. Perform MakeConstructor(closure).
         closure.MakeConstructor(vm);

--- a/JSS.Lib/AST/Values/BuiltinFunction.cs
+++ b/JSS.Lib/AST/Values/BuiltinFunction.cs
@@ -62,8 +62,9 @@ internal sealed class BuiltinFunction : Object, ICallable, IConstructable
         return result;
     }
 
-    // 10.3.4 CreateBuiltinFunction ( behaviour, FIXME: length, FIXME: name, FIXME: additionalInternalSlotsList [ , realm [ , prototype [ , FIXME: prefix ] ] ] ), https://tc39.es/ecma262/#sec-createbuiltinfunction
-    static public BuiltinFunction CreateBuiltinFunction(VM vm, Func<VM, Value, List, Completion> behaviour, Realm? realm = null, Object? prototype = null)
+    // 10.3.4 CreateBuiltinFunction ( behaviour, length, name, FIXME: additionalInternalSlotsList [ , realm [ , prototype [ , prefix ] ] ] ), https://tc39.es/ecma262/#sec-createbuiltinfunction
+    static public BuiltinFunction CreateBuiltinFunction(VM vm, Func<VM, Value, List, Completion> behaviour, int length, string name,
+        Realm? realm = null, Object? prototype = null, string prefix = "")
     {
         // 1. If realm is not present, set realm to the current Realm Record.
         realm ??= vm.Realm;
@@ -88,12 +89,14 @@ internal sealed class BuiltinFunction : Object, ICallable, IConstructable
 
         // FIXME: 9. Set func.[[InitialName]] to null.
 
-        // FIXME: 10. Perform SetFunctionLength(func, length).
+        // 10. Perform SetFunctionLength(func, length).
+        FunctionObject.SetFunctionLength(vm, func, length);
 
-        // FIXME: 11. If prefix is not present, then
-        // FIXME: a. Perform SetFunctionName(func, name).
-        // FIXME: 12. Else,
-        // FIXME: a. Perform SetFunctionName(func, name, prefix).
+        // 11. If prefix is not present, then
+        // a. Perform SetFunctionName(func, name).
+        // 12. Else,
+        // a. Perform SetFunctionName(func, name, prefix).
+        FunctionObject.SetFunctionName(vm, func, name, prefix);
 
         // 13. Return func.
         return func;

--- a/JSS.Lib/AST/Values/FunctionObject.cs
+++ b/JSS.Lib/AST/Values/FunctionObject.cs
@@ -386,6 +386,18 @@ internal sealed class FunctionObject : Object, ICallable, IConstructable
         // 7. Return unused.
     }
 
+    // 10.2.10 SetFunctionLength ( F, length ), https://tc39.es/ecma262/#sec-setfunctionlength
+    static public void SetFunctionLength(VM vm, Object F, int length)
+    {
+        // 1. Assert: FIXME: (F is an extensible object) that does not have a "length" own property.
+        Assert(!F.DataProperties.ContainsKey("length"), "1. Assert: F is an extensible object that does not have a \"length\" own property.");
+
+        // 2. Perform ! DefinePropertyOrThrow(F, "length", PropertyDescriptor { [[Value]]: 𝔽(length), [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }).
+        MUST(DefinePropertyOrThrow(vm, F, "length", new Property(length, new(false, false, true))));
+
+        // 3. Return unused.
+    }
+
     // 10.2.11 FunctionDeclarationInstantiation ( func, argumentsList ), https://tc39.es/ecma262/#sec-functiondeclarationinstantiation
     private Completion FunctionDeclarationInstantiation(VM vm, List argumentsList)
     {

--- a/JSS.Lib/AST/Values/FunctionObject.cs
+++ b/JSS.Lib/AST/Values/FunctionObject.cs
@@ -356,10 +356,10 @@ internal sealed class FunctionObject : Object, ICallable, IConstructable
     }
 
     // 10.2.9 SetFunctionName ( F, name [ , prefix ] ), https://tc39.es/ecma262/#sec-setfunctionname
-    public void SetFunctionName(VM vm, string name, string prefix = "")
+    static public void SetFunctionName(VM vm, Object F, string name, string prefix = "")
     {
         // 1. Assert: FIXME: (F is an extensible object) that does not have a "name" own property.
-        Assert(!DataProperties.ContainsKey("name"), "1. Assert: F is an extensible object that does not have a \"name\" own property.");
+        Assert(!F.DataProperties.ContainsKey("name"), "1. Assert: F is an extensible object that does not have a \"name\" own property.");
 
         // FIXME: 2. If name is a Symbol, then
         // FIXME: a. Let description be name's [[Description]] value.
@@ -381,7 +381,7 @@ internal sealed class FunctionObject : Object, ICallable, IConstructable
         }
 
         // 6. Perform ! DefinePropertyOrThrow(F, "name", PropertyDescriptor { [[Value]]: name, [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }).
-        MUST(DefinePropertyOrThrow(vm, this, "name", new Property(name, new Attributes(false, false, true))));
+        MUST(DefinePropertyOrThrow(vm, F, "name", new Property(name, new Attributes(false, false, true))));
 
         // 7. Return unused.
     }

--- a/JSS.Lib/Execution/Realm.cs
+++ b/JSS.Lib/Execution/Realm.cs
@@ -198,15 +198,15 @@ public sealed class Realm
 
         // 19.2 Function Properties of the Global Object
         // 19.2.1 eval ( x ), https://tc39.es/ecma262/#sec-eval-x
-        var evalBuiltinFunction = BuiltinFunction.CreateBuiltinFunction(vm, Eval.eval);
+        var evalBuiltinFunction = BuiltinFunction.CreateBuiltinFunction(vm, Eval.eval, 1, "eval");
         globalProperties.Add("eval", new(evalBuiltinFunction, new(true, false, true)));
 
         // 19.2.2 isFinite ( number )
-        var isFiniteBuiltinFunction = BuiltinFunction.CreateBuiltinFunction(vm, isFinite);
+        var isFiniteBuiltinFunction = BuiltinFunction.CreateBuiltinFunction(vm, isFinite, 1, "isFinite");
         globalProperties.Add("isFinite", new(isFiniteBuiltinFunction, new(true, false, true)));
 
         // 19.2.3 isNaN ( number )
-        var isNaNBuiltinFunction = BuiltinFunction.CreateBuiltinFunction(vm, isNaN);
+        var isNaNBuiltinFunction = BuiltinFunction.CreateBuiltinFunction(vm, isNaN, 1, "isNaN");
         globalProperties.Add("isNaN", new(isNaNBuiltinFunction, new(true, false, true)));
 
         // 19.3 Constructor Properties of the Global Object

--- a/JSS.Lib/Runtime/Array.constructor.cs
+++ b/JSS.Lib/Runtime/Array.constructor.cs
@@ -14,7 +14,7 @@ internal sealed class ArrayConstructor : Object
     public void Initialize(Realm realm, VM vm)
     {
         // 23.1.2.2 Array.isArray ( arg ), https://tc39.es/ecma262/#sec-array.isarray
-        var isArrayBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, isArray);
+        var isArrayBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, isArray, 1, "isArray");
         DataProperties.Add("isArray", new(isArrayBuiltin, new(true, false, true)));
 
         // 23.1.2.4 Array.prototype, https://tc39.es/ecma262/#sec-array.prototype

--- a/JSS.Lib/Runtime/Array.prototype.cs
+++ b/JSS.Lib/Runtime/Array.prototype.cs
@@ -15,11 +15,11 @@ internal sealed class ArrayPrototype : Object
     public void Initialize(VM vm)
     {
         // 23.1.3.18 Array.prototype.join ( separator ), https://tc39.es/ecma262/#sec-array.prototype.join
-        var joinBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, join);
+        var joinBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, join, 1, "join");
         DataProperties.Add("join", new(joinBuiltin, new(true, false, true)));
 
         // 23.1.3.23 Array.prototype.push ( ...items ), https://tc39.es/ecma262/#sec-array.prototype.push
-        var pushBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, push);
+        var pushBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, push, 1, "push");
         DataProperties.Add("push", new(pushBuiltin, new(true, false, true)));
     }
 

--- a/JSS.Lib/Runtime/Error.prototype.cs
+++ b/JSS.Lib/Runtime/Error.prototype.cs
@@ -23,7 +23,7 @@ internal sealed class ErrorPrototype : Object
         DataProperties.Add("name", new Property("Error", new(true, false, false)));
 
         // 20.5.3.4 Error.prototype.toString ( ), https://tc39.es/ecma262/#sec-error.prototype.tostring
-        var toStringBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, toString);
+        var toStringBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, toString, 0, "toString");
         DataProperties.Add("toString", new Property(toStringBuiltin, new(false, false, false)));
     }
 

--- a/JSS.Lib/Runtime/Function.prototype.cs
+++ b/JSS.Lib/Runtime/Function.prototype.cs
@@ -14,7 +14,7 @@ internal sealed class FunctionPrototype : Object
     public void Initialize(VM vm)
     {
         // 20.2.3.3 Function.prototype.call ( thisArg, ...args ), https://tc39.es/ecma262/#sec-function.prototype.call
-        var callBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, call);
+        var callBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, call, 1, "call");
         DataProperties.Add("call", new Property(callBuiltin, new(true, false, true)));
     }
 

--- a/JSS.Lib/Runtime/MathObject.cs
+++ b/JSS.Lib/Runtime/MathObject.cs
@@ -14,7 +14,7 @@ internal sealed class MathObject : Object
     public void Initialize(VM vm)
     {
         // 21.3.2.26 Math.pow ( base, exponent ), https://tc39.es/ecma262/#sec-math.pow
-        var powBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, pow);
+        var powBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, pow, 2, "pow");
         DataProperties.Add("pow", new(powBuiltin, new(true, false, true)));
     }
 

--- a/JSS.Lib/Runtime/Object.constructor.cs
+++ b/JSS.Lib/Runtime/Object.constructor.cs
@@ -18,7 +18,7 @@ internal class ObjectConstructor : Object, ICallable, IConstructable
         DataProperties.Add("length", new Property(1, new Attributes(true, false, true)));
 
         // 20.1.2.4 Object.defineProperty ( O, P, Attributes ), https://tc39.es/ecma262/#sec-object.defineproperty
-        var definePropertyBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, defineProperty);
+        var definePropertyBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, defineProperty, 3, "defineProperty");
         DataProperties.Add("defineProperty", new Property(definePropertyBuiltin, new(true, false, true)));
 
         // 20.1.2.21 Object.prototype, The initial value of Object.prototype is the Object prototype object.
@@ -26,11 +26,11 @@ internal class ObjectConstructor : Object, ICallable, IConstructable
         DataProperties.Add("prototype", new Property(realm.ObjectPrototype, new(false, false, false)));
 
         // 20.1.2.8 Object.getOwnPropertyDescriptor ( O, P ), https://tc39.es/ecma262/#sec-object.getownpropertydescriptor
-        var getOwnPropertyDescriptorBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, getOwnPropertyDescriptor);
+        var getOwnPropertyDescriptorBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, getOwnPropertyDescriptor, 2, "getOwnPropertyDescriptor");
         DataProperties.Add("getOwnPropertyDescriptor", new Property(getOwnPropertyDescriptorBuiltin, new(true, false, true)));
 
         // 20.1.2.10 Object.getOwnPropertyNames ( O ), https://tc39.es/ecma262/#sec-object.getownpropertynames
-        var getOwnPropertyNamesBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, getOwnPropertyNames);
+        var getOwnPropertyNamesBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, getOwnPropertyNames, 1, "getOwnPropertyNames");
         DataProperties.Add("getOwnPropertyNames", new Property(getOwnPropertyNamesBuiltin, new(true, false, true)));
     }
 

--- a/JSS.Lib/Runtime/Object.prototype.cs
+++ b/JSS.Lib/Runtime/Object.prototype.cs
@@ -17,11 +17,11 @@ internal class ObjectPrototype : Object
         DataProperties.Add("constructor", new Property(realm.ObjectConstructor, new Attributes(true, false, true)));
 
         // 20.1.3.2 Object.prototype.hasOwnProperty ( V ), https://tc39.es/ecma262/#sec-object.prototype.hasownproperty
-        var hasOwnPropertyBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, hasOwnProperty);
+        var hasOwnPropertyBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, hasOwnProperty, 1, "hasOwnProperty");
         DataProperties.Add("hasOwnProperty", new Property(hasOwnPropertyBuiltin, new Attributes(true, false, true)));
 
         // 20.1.3.6 Object.prototype.toString ( ), https://tc39.es/ecma262/#sec-object.prototype.tostring
-        var toStringBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, toString);
+        var toStringBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, toString, 0, "toString");
         DataProperties.Add("toString", new Property(toStringBuiltin, new Attributes(true, false, true)));
     }
 

--- a/JSS.Lib/Runtime/Test262Object.cs
+++ b/JSS.Lib/Runtime/Test262Object.cs
@@ -11,13 +11,13 @@ internal sealed class Test262Object : Object
 
     public void Initialize(VM vm)
     {
-        var createRealmBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, createRealm);
+        var createRealmBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, createRealm, 0, "createRealm");
         DataProperties.Add("createRealm", new Property(createRealmBuiltin, new(true, false, true)));
 
-        var evalScriptBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, evalScript);
+        var evalScriptBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, evalScript, 1, "evalScript");
         DataProperties.Add("evalScript", new Property(evalScriptBuiltin, new(true, false, true)));
 
-        var gcBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, gc);
+        var gcBuiltin = BuiltinFunction.CreateBuiltinFunction(vm, gc, 0, "gc");
         DataProperties.Add("gc", new Property(gcBuiltin, new(true, false, true)));
 
         // global, a reference to the global object on which $262 was initially defined


### PR DESCRIPTION
We now define the name and length of builtin functions when they are created.

Example Code:
```js
eval.name; // Returns "eval"
eval.length; // Returns 1
```