### PR TITLE
JSS-74 Implement parsing and execution of arrow functions

### DIFF
--- a/JSS.Lib/AST/ArrowFunctionExpression.cs
+++ b/JSS.Lib/AST/ArrowFunctionExpression.cs
@@ -1,0 +1,16 @@
+﻿namespace JSS.Lib.AST;
+
+// 15.3 Arrow Function Definitions, https://tc39.es/ecma262/#sec-arrow-function-definitions
+internal sealed class ArrowFunctionExpression : IExpression
+{
+    public ArrowFunctionExpression(List<Identifier> parameters, INode body, bool isStrict)
+    {
+        Parameters = parameters;
+        Body = body;
+        IsStrict = isStrict;
+    }
+
+    public List<Identifier> Parameters { get; }
+    public INode Body { get; }
+    public bool IsStrict { get; }
+}

--- a/JSS.Lib/AST/ArrowFunctionExpression.cs
+++ b/JSS.Lib/AST/ArrowFunctionExpression.cs
@@ -1,4 +1,7 @@
-﻿namespace JSS.Lib.AST;
+﻿using JSS.Lib.AST.Values;
+using JSS.Lib.Execution;
+
+namespace JSS.Lib.AST;
 
 // 15.3 Arrow Function Definitions, https://tc39.es/ecma262/#sec-arrow-function-definitions
 internal sealed class ArrowFunctionExpression : IExpression
@@ -8,6 +11,36 @@ internal sealed class ArrowFunctionExpression : IExpression
         Parameters = parameters;
         Body = body;
         IsStrict = isStrict;
+    }
+
+
+    // 15.3.4 Runtime Semantics: InstantiateArrowFunctionExpression, https://tc39.es/ecma262/#sec-runtime-semantics-instantiatearrowfunctionexpression
+    private Completion InstantiateArrowFunctionExpression(VM vm, string name = "")
+    {
+        // 1. If name is not present, set name to "".
+
+        // 2. Let env be the LexicalEnvironment of the running execution context.
+        var scriptExecutionContext = (vm.CurrentExecutionContext as ScriptExecutionContext)!;
+        var env = scriptExecutionContext.LexicalEnvironment;
+
+        // FIXME: 3. Let privateEnv be the running execution context's PrivateEnvironment.
+        // FIXME: 4. Let sourceText be the source text matched by ArrowFunction.
+
+        // 5. Let closure be OrdinaryFunctionCreate(%Function.prototype%, sourceText, ArrowParameters, ConciseBody, lexical-this, env, privateEnv).
+        var closure = FunctionObject.OrdinaryFunctionCreate(vm.FunctionPrototype, Parameters, Body, LexicalThisMode.LEXICAL_THIS, env!, IsStrict);
+
+        // 6. Perform SetFunctionName(closure, name).
+        FunctionObject.SetFunctionName(vm, closure, name);
+
+        // 7. Return closure.
+        return closure;
+    }
+
+    // 15.3.5 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-arrow-function-definitions-runtime-semantics-evaluation
+    public override Completion Evaluate(VM vm)
+    {
+        // 1. Return InstantiateArrowFunctionExpression of ArrowFunction.
+        return InstantiateArrowFunctionExpression(vm);
     }
 
     public List<Identifier> Parameters { get; }

--- a/JSS.Lib/AST/ExpressionBody.cs
+++ b/JSS.Lib/AST/ExpressionBody.cs
@@ -1,4 +1,6 @@
-﻿namespace JSS.Lib.AST;
+﻿using JSS.Lib.Execution;
+
+namespace JSS.Lib.AST;
 
 // 15.3 Arrow Function Definitions, https://tc39.es/ecma262/#sec-arrow-function-definitions
 internal sealed class ExpressionBody : INode
@@ -6,6 +8,21 @@ internal sealed class ExpressionBody : INode
     public ExpressionBody(IExpression expression)
     {
         Expression = expression;
+    }
+
+    // 15.3.5 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-arrow-function-definitions-runtime-semantics-evaluation
+    public override Completion Evaluate(VM vm)
+    {
+        // 1. Let exprRef be ? Evaluation of AssignmentExpression.
+        var exprRef = Expression.Evaluate(vm);
+        if (exprRef.IsAbruptCompletion()) return exprRef;
+
+        // 2. Let exprValue be ? GetValue(exprRef).
+        var exprValue = exprRef.Value.GetValue(vm);
+        if (exprValue.IsAbruptCompletion()) return exprValue;
+
+        // 3. Return Completion Record { [[Type]]: return, [[Value]]: exprValue, [[Target]]: empty }.
+        return Completion.ReturnCompletion(exprValue.Value);
     }
 
     public IExpression Expression { get; }

--- a/JSS.Lib/AST/ExpressionBody.cs
+++ b/JSS.Lib/AST/ExpressionBody.cs
@@ -1,0 +1,12 @@
+﻿namespace JSS.Lib.AST;
+
+// 15.3 Arrow Function Definitions, https://tc39.es/ecma262/#sec-arrow-function-definitions
+internal sealed class ExpressionBody : INode
+{
+    public ExpressionBody(IExpression expression)
+    {
+        Expression = expression;
+    }
+
+    public IExpression Expression { get; }
+}

--- a/JSS.Lib/AST/Values/FunctionObject.cs
+++ b/JSS.Lib/AST/Values/FunctionObject.cs
@@ -252,7 +252,7 @@ internal sealed class FunctionObject : Object, ICallable, IConstructable
     }
 
     // 10.2.3 OrdinaryFunctionCreate ( FIXME: functionPrototype, FIXME: sourceText, ParameterList, Body, thisMode, env, FIXME: privateEnv ), https://tc39.es/ecma262/#sec-ordinaryfunctioncreate
-    static public FunctionObject OrdinaryFunctionCreate(Object functionPrototype, IReadOnlyList<Identifier> parameterList, StatementList body, LexicalThisMode thisMode,
+    static public FunctionObject OrdinaryFunctionCreate(Object functionPrototype, IReadOnlyList<Identifier> parameterList, INode body, LexicalThisMode thisMode,
         Environment env, bool isStrict)
     {
         // 1. Let internalSlotsList be the internal slots listed in Table 30.
@@ -770,7 +770,7 @@ internal sealed class FunctionObject : Object, ICallable, IConstructable
 
 
     public IReadOnlyList<Identifier> FormalParameters { get; private set; }
-    public StatementList ECMAScriptCode { get; private set; }
+    public INode ECMAScriptCode { get; private set; }
     public Environment Environment { get; private set; }
     public ThisMode ThisMode { get; private set; }
     public ConstructorKind ConstructorKind { get; private set; }

--- a/JSS.Lib/ErrorHelper.cs
+++ b/JSS.Lib/ErrorHelper.cs
@@ -2,6 +2,7 @@
 
 internal enum ErrorType
 {
+    ArrowFunctionHeadHasLineTerminator,
     ConstWithoutInitializer,
     IllegalNewLineAfterThrow,
     TryWithoutCatchOrFinally,
@@ -35,6 +36,7 @@ internal sealed class ErrorHelper
 
     static private readonly Dictionary<ErrorType, string> errorTypeToFormatString = new()
     {
+        { ErrorType.ArrowFunctionHeadHasLineTerminator, "SyntaxError: An arrow function's '=>' should be on the same line as their arguments." },
         { ErrorType.ConstWithoutInitializer, "SyntaxError: Missing initializer in const declaration" },
         { ErrorType.IllegalNewLineAfterThrow, "SyntaxError: Illegal newline after throw" },
         { ErrorType.TryWithoutCatchOrFinally, "SyntaxError: Try statement without catch or finally blocks" },


### PR DESCRIPTION
We now support parsing and execution of arrow function expression.

This allows for use of arrow functions inside of JSS.

Example Code:
```js
var c = a => b => a + b; // A complex arrow function closure
c(1)(2); // Returns 3 as expected
```