### PR TITLE
JSS-76 Implement internal support for new targets for calls and constructors

### DIFF
--- a/JSS.Lib/AST/NewExpression.cs
+++ b/JSS.Lib/AST/NewExpression.cs
@@ -53,7 +53,7 @@ internal sealed class NewExpression : IExpression
 
         // 6. Return ? Construct(constructor, argList).
         var constructable = constructor.Value.AsConstructable();
-        return constructable.Construct(vm, argList);
+        return IConstructable.Construct(vm, constructable, argList);
     }
 
     public IExpression Expression { get; }

--- a/JSS.Lib/AST/Values/IConstructable.cs
+++ b/JSS.Lib/AST/Values/IConstructable.cs
@@ -20,8 +20,8 @@ internal interface IConstructable
         argumentsList ??= new List();
 
         // 3. Return ? F.[[Construct]](argumentsList, newTarget).
-        return F.Construct(vm, argumentsList);
+        return F.Construct(vm, argumentsList, (newTarget as Object)!);
     }
 
-    public Completion Construct(VM vm, List argumentsList);
+    public Completion Construct(VM vm, List argumentsList, Object newTarget);
 }

--- a/JSS.Lib/AST/Values/IConstructable.cs
+++ b/JSS.Lib/AST/Values/IConstructable.cs
@@ -11,9 +11,10 @@ enum ConstructorKind
 internal interface IConstructable
 {
     // 7.3.15 Construct ( F [ , argumentsList [ , newTarget ] ] ), https://tc39.es/ecma262/#sec-construct
-    static public Completion Construct(VM vm, IConstructable F, List? argumentsList)
+    static public Completion Construct(VM vm, IConstructable F, List? argumentsList, IConstructable? newTarget = null)
     {
-        // FIXME: 1. If newTarget is not present, set newTarget to F.
+        // 1. If newTarget is not present, set newTarget to F.
+        newTarget ??= F;
 
         // 2. If argumentsList is not present, set argumentsList to a new empty List.
         argumentsList ??= new List();

--- a/JSS.Lib/Execution/Eval.cs
+++ b/JSS.Lib/Execution/Eval.cs
@@ -6,7 +6,7 @@ namespace JSS.Lib.Execution;
 internal static class Eval
 {
     // 19.2.1 eval ( x ), https://tc39.es/ecma262/#sec-eval-x
-    static public Completion eval(VM vm, Value thisValue, List argumentList)
+    static public Completion eval(VM vm, Value thisValue, List argumentList, Object newTarget)
     {
         // 1. Return ? PerformEval(x, false, false).
         return PerformEval(vm, argumentList[0], false, false);

--- a/JSS.Lib/Execution/Realm.cs
+++ b/JSS.Lib/Execution/Realm.cs
@@ -295,7 +295,7 @@ public sealed class Realm
     }
 
     // 19.2.2 isFinite ( number ), https://tc39.es/ecma262/#sec-isfinite-number
-    static private Completion isFinite(VM vm, Value thisValue, List argumentList)
+    static private Completion isFinite(VM vm, Value thisValue, List argumentList, Object newTarget)
     {
         // 1. Let num be ? ToNumber(number).
         var num = argumentList[0].ToNumber(vm);
@@ -307,7 +307,7 @@ public sealed class Realm
     }
 
     // 19.2.3 isNaN ( number ), https://tc39.es/ecma262/#sec-isnan-number
-    static private Completion isNaN(VM vm, Value thisValue, List argumentList)
+    static private Completion isNaN(VM vm, Value thisValue, List argumentList, Object newTarget)
     {
         // 1. Let num be ? ToNumber(number).
         var num = argumentList[0].ToNumber(vm);

--- a/JSS.Lib/Execution/ThrowHelper.cs
+++ b/JSS.Lib/Execution/ThrowHelper.cs
@@ -78,7 +78,7 @@ internal static class ThrowHelper
     {
         List arguments = new();
         arguments.Values.Add(message);
-        var constructResult = constructor.Construct(vm, arguments);
+        var constructResult = constructor.Construct(vm, arguments, Undefined.The);
         if (constructResult.IsAbruptCompletion()) return constructResult;
         return Completion.ThrowCompletion(constructResult.Value);
     }

--- a/JSS.Lib/Runtime/Array.constructor.cs
+++ b/JSS.Lib/Runtime/Array.constructor.cs
@@ -22,7 +22,7 @@ internal sealed class ArrayConstructor : Object
     }
 
     // 23.1.2.2 Array.isArray ( arg ), https://tc39.es/ecma262/#sec-array.isarray
-    private Completion isArray(VM vm, Value thisArgument, List argumentList)
+    private Completion isArray(VM vm, Value thisArgument, List argumentList, Object newTarget)
     {
         // 1. Return ? IsArray(arg).
         return argumentList[0].IsArray();

--- a/JSS.Lib/Runtime/Array.prototype.cs
+++ b/JSS.Lib/Runtime/Array.prototype.cs
@@ -24,7 +24,7 @@ internal sealed class ArrayPrototype : Object
     }
 
     // 23.1.3.18 Array.prototype.join ( separator ), https://tc39.es/ecma262/#sec-array.prototype.join
-    private Completion join(VM vm, Value thisArgument, List argumentList)
+    private Completion join(VM vm, Value thisArgument, List argumentList, Object newTarget)
     {
         // 1. Let O be ? ToObject(this value).
         var O = thisArgument.ToObject(vm);
@@ -88,7 +88,7 @@ internal sealed class ArrayPrototype : Object
     }
 
     // 23.1.3.23 Array.prototype.push ( ...items ), https://tc39.es/ecma262/#sec-array.prototype.push
-    private Completion push(VM vm, Value thisArgument, List argumentList)
+    private Completion push(VM vm, Value thisArgument, List argumentList, Object newTarget)
     {
         // 1. Let O be ? ToObject(this value).
         var O = thisArgument.ToObject(vm);

--- a/JSS.Lib/Runtime/Error.constructor.cs
+++ b/JSS.Lib/Runtime/Error.constructor.cs
@@ -22,11 +22,11 @@ internal sealed class ErrorConstructor : Object, ICallable, IConstructable
     // 20.5.1.1 Error ( message [ , options ] ), https://tc39.es/ecma262/#sec-error-message
     public Completion Call(VM vm, Value thisArgument, List argumentList)
     {
-        return Construct(vm, argumentList);
+        return Construct(vm, argumentList, Undefined.The);
     }
 
     // 20.5.1.1 Error ( message [ , options ] ), https://tc39.es/ecma262/#sec-error-message
-    public Completion Construct(VM vm, List argumentsList)
+    public Completion Construct(VM vm, List argumentsList, Object newTarget)
     {
         // FIXME: 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
 

--- a/JSS.Lib/Runtime/Error.prototype.cs
+++ b/JSS.Lib/Runtime/Error.prototype.cs
@@ -28,7 +28,7 @@ internal sealed class ErrorPrototype : Object
     }
 
     // 20.5.3.4 Error.prototype.toString ( ), https://tc39.es/ecma262/#sec-error.prototype.tostring
-    private Completion toString(VM vm, Value thisArgument, List argumentList)
+    private Completion toString(VM vm, Value thisArgument, List argumentList, Object newTarget)
     {
         // 1. Let O be the this value.
 

--- a/JSS.Lib/Runtime/Function.prototype.cs
+++ b/JSS.Lib/Runtime/Function.prototype.cs
@@ -19,7 +19,7 @@ internal sealed class FunctionPrototype : Object
     }
 
     // 20.2.3.3 Function.prototype.call ( thisArg, ...args ), https://tc39.es/ecma262/#sec-function.prototype.call
-    private Completion call(VM vm, Value thisArg, List argumentList)
+    private Completion call(VM vm, Value thisArg, List argumentList, Object newTarget)
     {
         // 1. Let func be the this value.
         var func = thisArg;

--- a/JSS.Lib/Runtime/MathObject.cs
+++ b/JSS.Lib/Runtime/MathObject.cs
@@ -19,7 +19,7 @@ internal sealed class MathObject : Object
     }
 
     // 21.3.2.26 Math.pow ( base, exponent ), https://tc39.es/ecma262/#sec-math.pow
-    private Completion pow(VM vm, Value thisArgument, List argumentList)
+    private Completion pow(VM vm, Value thisArgument, List argumentList, Object newTarget)
     {
         // 1. Set base to ? ToNumber(base).
         var powBase = argumentList[0].ToNumber(vm);

--- a/JSS.Lib/Runtime/NativeError.constructor.cs
+++ b/JSS.Lib/Runtime/NativeError.constructor.cs
@@ -25,11 +25,11 @@ internal class NativeErrorConstructor : Object, ICallable, IConstructable
     // 20.5.6.1.1 NativeError ( message [ , options ] ), https://tc39.es/ecma262/#sec-nativeerror
     public Completion Call(VM vm, Value thisArgument, List argumentList)
     {
-        return Construct(vm, argumentList);
+        return Construct(vm, argumentList, Undefined.The);
     }
 
     // 20.5.6.1.1 NativeError ( message [ , options ] ), https://tc39.es/ecma262/#sec-nativeerror
-    public Completion Construct(VM vm, List argumentsList)
+    public Completion Construct(VM vm, List argumentsList, Object newTarget)
     {
         // FIXME: 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
 

--- a/JSS.Lib/Runtime/Object.constructor.cs
+++ b/JSS.Lib/Runtime/Object.constructor.cs
@@ -37,11 +37,11 @@ internal class ObjectConstructor : Object, ICallable, IConstructable
     // 20.1.1.1 Object ( [ value ] ), https://tc39.es/ecma262/#sec-object-value
     public Completion Call(VM vm, Value thisArgument, List argumentList)
     {
-        return Construct(vm, argumentList); 
+        return Construct(vm, argumentList, Undefined.The); 
     }
 
     // 20.1.1.1 Object ( [ value ] ), https://tc39.es/ecma262/#sec-object-value 
-    public Completion Construct(VM vm, List argumentList)
+    public Completion Construct(VM vm, List argumentList, Object newTarget)
     {
         // FIXME: 1. If NewTarget is neither undefined nor the active function object, then
         // FIXME: a. Return ? OrdinaryCreateFromConstructor(NewTarget, "%Object.prototype%").
@@ -58,7 +58,7 @@ internal class ObjectConstructor : Object, ICallable, IConstructable
     }
 
     // 20.1.2.4 Object.defineProperty ( O, P, Attributes ), https://tc39.es/ecma262/#sec-object.defineproperty
-    private Completion defineProperty(VM vm, Value thisArgument, List argumentList)
+    private Completion defineProperty(VM vm, Value thisArgument, List argumentList, Object newTarget)
     {
         // 1. If O is not an Object, throw a TypeError exception.
         var O = argumentList[0];
@@ -80,7 +80,7 @@ internal class ObjectConstructor : Object, ICallable, IConstructable
     }
 
     // 20.1.2.8 Object.getOwnPropertyDescriptor ( O, P ), https://tc39.es/ecma262/#sec-object.getownpropertydescriptor
-    private Completion getOwnPropertyDescriptor(VM vm, Value thisArgument, List argumentList)
+    private Completion getOwnPropertyDescriptor(VM vm, Value thisArgument, List argumentList, Object newTarget)
     {
         // 1. Let obj be ? ToObject(O).
         var obj = argumentList[0].ToObject(vm);
@@ -100,7 +100,7 @@ internal class ObjectConstructor : Object, ICallable, IConstructable
     }
 
     // 20.1.2.10 Object.getOwnPropertyNames ( O ), https://tc39.es/ecma262/#sec-object.getownpropertynames
-    private Completion getOwnPropertyNames(VM vm, Value thisArgument, List argumentList)
+    private Completion getOwnPropertyNames(VM vm, Value thisArgument, List argumentList, Object newTarget)
     {
         // 1. Return CreateArrayFromList(? GetOwnPropertyKeys(O, STRING)).
         var ownPropertyKeys = GetOwnPropertyKeys(vm, argumentList[0]);

--- a/JSS.Lib/Runtime/Object.prototype.cs
+++ b/JSS.Lib/Runtime/Object.prototype.cs
@@ -26,7 +26,7 @@ internal class ObjectPrototype : Object
     }
 
     // 20.1.3.2 Object.prototype.hasOwnProperty ( V ), https://tc39.es/ecma262/#sec-object.prototype.hasownproperty
-    private Completion hasOwnProperty(VM vm, Value thisValue, List argumentList)
+    private Completion hasOwnProperty(VM vm, Value thisValue, List argumentList, Object newTarget)
     {
         // 1. Let P be ? ToPropertyKey(V).
         var P = argumentList[0].ToPropertyKey(vm);
@@ -41,7 +41,7 @@ internal class ObjectPrototype : Object
     }
 
     // 20.1.3.6 Object.prototype.toString ( ), https://tc39.es/ecma262/#sec-object.prototype.tostring
-    private Completion toString(VM vm, Value thisValue, List argumentList)
+    private Completion toString(VM vm, Value thisValue, List argumentList, Object newTarget)
     {
         // 1. If the this value is undefined, return "[object Undefined]".
         if (thisValue.IsUndefined()) return "[object Undefined]";

--- a/JSS.Lib/Runtime/String.constructor.cs
+++ b/JSS.Lib/Runtime/String.constructor.cs
@@ -36,7 +36,7 @@ internal class StringConstructor : Object, ICallable, IConstructable
     }
 
     // 22.1.1.1 String ( value ), https://tc39.es/ecma262/#sec-string-constructor-string-value
-    public Completion Construct(VM vm, List argumentsList)
+    public Completion Construct(VM vm, List argumentsList, Object newTarget)
     {
         throw new NotImplementedException();
     }

--- a/JSS.Lib/Runtime/Test262Object.cs
+++ b/JSS.Lib/Runtime/Test262Object.cs
@@ -24,7 +24,7 @@ internal sealed class Test262Object : Object
         DataProperties.Add("global", new Property(vm.Realm.GlobalObject, new(true, false, true)));
     }
 
-    private Completion createRealm(VM _, Value thisValue, List argumentList)
+    private Completion createRealm(VM _, Value thisValue, List argumentList, Object newTarget)
     {
         // createRealm - a function which creates a new ECMAScript Realm, defines this API on the new realm's global object,
         // and returns the $262 property of the new realm's global object
@@ -38,7 +38,7 @@ internal sealed class Test262Object : Object
     }
 
     // evalScript - a function which accepts a string value as its first argument and executes it as an ECMAScript script
-    private Completion evalScript(VM vm, Value thisValue, List argumentList)
+    private Completion evalScript(VM vm, Value thisValue, List argumentList, Object newTarget)
     {
         // 1. Let hostDefined be any host-defined values for the provide sourceText (obtained in an implementation dependent manner)
         var sourceText = argumentList[0].AsString();
@@ -66,7 +66,7 @@ internal sealed class Test262Object : Object
         return s!.ScriptEvaluation();
     }
 
-    private Completion gc(VM vm, Value thisValue, List argumentList)
+    private Completion gc(VM vm, Value thisValue, List argumentList, Object newTarget)
     {
         // gc, a function that wraps the host's garbage collection invocation mechanism
         GC.Collect();


### PR DESCRIPTION
When a function is called or constructed we now properly track the newTarget of the call or construct.

This will allow us to implement steps based on newTarget as defined in the spec.