### PR TITLE
JSS-78 Implement the string constructor

### DIFF
--- a/JSS.Lib/AST/Values/StringObject.cs
+++ b/JSS.Lib/AST/Values/StringObject.cs
@@ -1,4 +1,4 @@
-﻿using JSS.Lib.Runtime;
+﻿using JSS.Lib.Execution;
 
 namespace JSS.Lib.AST.Values;
 
@@ -8,9 +8,26 @@ internal sealed class StringObject : Object
     // FIXME: String instances are String exotic objects and have the internal methods specified for such objects.
     // FIXME: String instances inherit properties from the String prototype object.
     // FIXME: String instances have a "length" property, and a set of enumerable properties with integer-indexed names.
-    public StringObject(ObjectPrototype prototype, String value) : base(prototype)
+    // 10.4.3.4 StringCreate ( value, prototype ), https://tc39.es/ecma262/#sec-stringcreate
+    public StringObject(VM vm, String value, Object prototype) : base(prototype)
     {
+        // 1. Let S be MakeBasicObject(« [[Prototype]], [[Extensible]], [[StringData]] »).
+        // 2. Set S.[[Prototype]] to prototype.
+
+        // 3. Set S.[[StringData]] to value.
         StringData = value;
+
+        // FIXME: 4. Set S.[[GetOwnProperty]] as specified in 10.4.3.1.
+        // FIXME: 5. Set S.[[DefineOwnProperty]] as specified in 10.4.3.2.
+        // FIXME: 6. Set S.[[OwnPropertyKeys]] as specified in 10.4.3.3.
+
+        // 7. Let length be the length of value.
+        var length = value.Value.Length;
+
+        // 8. Perform ! DefinePropertyOrThrow(S, "length", PropertyDescriptor { [[Value]]: 𝔽(length), [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }).
+        MUST(DefinePropertyOrThrow(vm, this, "length", new(length, new(false, false, false))));
+
+        // 9. Return S.
     }
 
     // [[StringData]]

--- a/JSS.Lib/AST/Values/Value.cs
+++ b/JSS.Lib/AST/Values/Value.cs
@@ -622,7 +622,7 @@ public abstract class Value
         // String, Return a new String object whose [[StringData]] internal slot is set to argument.
         if (IsString())
         {
-            return new StringObject(vm.ObjectPrototype, AsString());
+            return new StringObject(vm, AsString(), vm.ObjectPrototype);
         }
 
         // FIXME: Implement the rest of the conversions

--- a/JSS.Lib/Runtime/String.constructor.cs
+++ b/JSS.Lib/Runtime/String.constructor.cs
@@ -13,31 +13,34 @@ internal class StringConstructor : Object, ICallable, IConstructable
     // 22.1.1.1 String ( value ), https://tc39.es/ecma262/#sec-string-constructor-string-value
     public Completion Call(VM vm, Value thisArgument, List argumentList)
     {
-        // 1. If value is not present, then
-        string s;
-        if (argumentList.Values.Count == 0)
-        {
-            s = "";
-        }
-        else
-        {
-            // FIXME: a. If NewTarget is undefined and value is a Symbol, return SymbolDescriptiveString(value).
-
-            // b. Let s be ? ToString(value).
-            var value = argumentList.Values[0];
-            var abruptOrS = value.ToStringJS(vm);
-            if (abruptOrS.IsAbruptCompletion()) return abruptOrS.Completion;
-            s = abruptOrS.Value;
-        }
-
-        // NOTE/FIXME: I think this is always true for calls
-        // 3. If NewTarget is undefined, return s.
-        return s; 
+        return Construct(vm, argumentList, Undefined.The);
     }
 
     // 22.1.1.1 String ( value ), https://tc39.es/ecma262/#sec-string-constructor-string-value
     public Completion Construct(VM vm, List argumentsList, Object newTarget)
     {
-        throw new NotImplementedException();
+        // 1. If value is not present, then
+        string s;
+        if (argumentsList.Values.Count == 0)
+        {
+            s = "";
+        }
+        // 2. Else,
+        else
+        {
+            // FIXME: a. If NewTarget is undefined and value is a Symbol, return SymbolDescriptiveString(value).
+
+            // b. Let s be ? ToString(value).
+            var value = argumentsList.Values[0];
+            var abruptOrS = value.ToStringJS(vm);
+            if (abruptOrS.IsAbruptCompletion()) return abruptOrS.Completion;
+            s = abruptOrS.Value;
+        }
+
+        // 3. If NewTarget is undefined, return s.
+        if (newTarget.IsUndefined()) return s;
+
+        // 4. Return StringCreate(s, FIXME: ? GetPrototypeFromConstructor(NewTarget, "%String.prototype%")).
+        return new StringObject(vm, s, vm.ObjectPrototype);
     }
 }


### PR DESCRIPTION
We now have support for the string constructor.

Example Code:
```js
var obj = new String("data");
var obj2 = new Object("data"); // Both objs are string objects with an internal [[StringData]] slot containing "data"
```