### PR TITLE
JSS-75 Implement support for data inside of array literals

### DIFF
--- a/JSS.Lib.UnitTests/ParserTests.cs
+++ b/JSS.Lib.UnitTests/ParserTests.cs
@@ -2118,7 +2118,6 @@ internal sealed class ParserTests
         assignmentExpression.Rhs.Should().BeOfType(expectedExpressionType);
     }
 
-    // FIXME: More tests when we don't only parse empty array literals
     // Tests for ArrayLiteral
     [Test]
     public void Parse_ReturnsAssignment_WithArrayLiteralRHS_WhenProvidingAssignment_WithArrayLiteralRHS()
@@ -2141,6 +2140,58 @@ internal sealed class ParserTests
 
         var objectLiteral = assignmentExpression!.Rhs as ArrayLiteral;
         objectLiteral.Should().NotBeNull();
+        objectLiteral!.Elements.Should().HaveCount(0);
+    }
+
+    [TestCaseSource(nameof(expressionToExpectedTypeTestCases))]
+    public void Parse_ReturnsArrayLiteral_WithAssignmentExpressionData_WhenProvidingArrayLiteral_WithDataElement(KeyValuePair<string, Type> expressionToExpectedType)
+    {
+        // Arrange
+        var expression = expressionToExpectedType.Key;
+        var expectedExpressionType = expressionToExpectedType.Value;
+        var parser = new Parser($"[{expression}]");
+
+        // Act
+        var parsedProgram = ParseScript(parser);
+        var rootNodes = parsedProgram.ScriptCode;
+
+        // Assert
+        rootNodes.Should().HaveCount(1);
+
+        var expressionStatement = rootNodes[0] as ExpressionStatement;
+        expressionStatement.Should().NotBeNull();
+
+        var objectLiteral = expressionStatement!.Expression as ArrayLiteral;
+        objectLiteral.Should().NotBeNull();
+        objectLiteral!.Elements.Should().HaveCount(1);
+
+        var element = objectLiteral.Elements[0];
+        element.Should().NotBeNull();
+        element.Should().BeOfType(expectedExpressionType);
+    }
+
+    [Test]
+    public void Parse_ReturnsArrayLiteral_WithNullDataElement_WhenProvidingArrayLiteral_WithElision()
+    {
+        // Arrange
+        var parser = new Parser("[,]");
+
+        // Act
+        var parsedProgram = ParseScript(parser);
+        var rootNodes = parsedProgram.ScriptCode;
+
+        // Assert
+        rootNodes.Should().HaveCount(1);
+
+        var expressionStatement = rootNodes[0] as ExpressionStatement;
+        expressionStatement.Should().NotBeNull();
+
+        var objectLiteral = expressionStatement!.Expression as ArrayLiteral;
+        objectLiteral.Should().NotBeNull();
+        objectLiteral!.Elements.Should().HaveCount(1);
+
+        var element = objectLiteral.Elements[0];
+        element.Should().BeNull();
     }
 
     // FIXME: More tests when we don't only parse empty object literals

--- a/JSS.Lib/AST/Literal/ArrayLiteral.cs
+++ b/JSS.Lib/AST/Literal/ArrayLiteral.cs
@@ -12,12 +12,59 @@ internal sealed class ArrayLiteral : IExpression
     // 13.2.4.2 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-array-initializer-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
-        // FIXME: Implement the rest of the evaluation when we parse element lists
         // 1. Let array be ! ArrayCreate(0).
         var array = MUST(Array.ArrayCreate(vm, 0));
 
+        // 2. Perform ? ArrayAccumulation of ElementList with arguments array and 0.
+        var accumulationResult = ArrayAccumulation(vm, array);
+        if (accumulationResult.IsAbruptCompletion()) return accumulationResult;
+
         // 3. Return array.
         return array;
+    }
+
+    // 13.2.4.1 Runtime Semantics: ArrayAccumulation, https://tc39.es/ecma262/#sec-runtime-semantics-arrayaccumulation
+    private Completion ArrayAccumulation(VM vm, Array array)
+    {
+        // FIXME/NOTE: This doesn't follow the spec steps exactly, however, this should fully mimic the behaviour.
+        var nextIndex = 0;
+        foreach (var element in Elements)
+        {
+            // 1. If Elision is present, then
+            if (element is null)
+            {
+                // 1. Let len be nextIndex + 1.
+                var len = nextIndex + 1;
+
+                // 2. Perform ? Set(array, "length", 𝔽(len), true).
+                var setResult = Object.Set(vm, array, "length", len, true);
+                if (setResult.IsAbruptCompletion()) return setResult;
+
+                // 3. NOTE: The above step throws if len exceeds 2**32 - 1.
+
+                // 4. Return len.
+                // a. Set nextIndex to ? ArrayAccumulation of Elision with arguments array and nextIndex.
+                nextIndex = len;
+            }
+            else
+            {
+                // 2. Let initResult be ? Evaluation of AssignmentExpression.
+                var initResult = element.Evaluate(vm);
+                if (initResult.IsAbruptCompletion()) return initResult;
+
+                // 3. Let initValue be ? GetValue(initResult).
+                var initValue = initResult.Value.GetValue(vm);
+
+                // 4. Perform ! CreateDataPropertyOrThrow(array, ! ToString(𝔽(nextIndex)), initValue).
+                MUST(Object.CreateDataPropertyOrThrow(vm, array, nextIndex.ToString(), initValue.Value));
+
+                // 5. Return nextIndex + 1.
+                nextIndex++;
+            }
+        }
+
+        // Other steps return the index in the happy path, so we return nextIndex here.
+        return nextIndex;
     }
 
     public IReadOnlyList<IExpression?> Elements { get; }

--- a/JSS.Lib/AST/Literal/ArrayLiteral.cs
+++ b/JSS.Lib/AST/Literal/ArrayLiteral.cs
@@ -4,6 +4,11 @@ namespace JSS.Lib.AST.Literal;
 
 internal sealed class ArrayLiteral : IExpression
 {
+    public ArrayLiteral(List<IExpression?> elements)
+    {
+        Elements = elements;
+    }
+
     // 13.2.4.2 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-array-initializer-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
@@ -14,4 +19,6 @@ internal sealed class ArrayLiteral : IExpression
         // 3. Return array.
         return array;
     }
+
+    public IReadOnlyList<IExpression?> Elements { get; }
 }

--- a/JSS.Lib/Parser.cs
+++ b/JSS.Lib/Parser.cs
@@ -1504,11 +1504,31 @@ public sealed class Parser
 
     private ArrayLiteral ParseArrayLiteral()
     {
-        // FIXME: Implement parsing of ElementList
         _consumer.ConsumeTokenOfType(TokenType.OpenSquare);
+
+        var elements = ParseElementList();
+
         _consumer.ConsumeTokenOfType(TokenType.ClosedSquare);
 
-        return new ArrayLiteral();
+        return new ArrayLiteral(elements);
+    }
+
+    private List<IExpression?> ParseElementList()
+    {
+        var elements = new List<IExpression?>();
+        while (!_consumer.IsTokenOfType(TokenType.ClosedSquare))
+        {
+            // FIXME: Parse SpreadElement
+            // NOTE: We count a null as an elision, if TryParseAssignmentExpression fails, expression will contain null
+            TryParseAssignmentExpression(out var expression);
+            elements.Add(expression);
+
+            // If there is no comma then we can't parse any more elements
+            if (!_consumer.IsTokenOfType(TokenType.Comma)) break;
+            _consumer.ConsumeTokenOfType(TokenType.Comma);
+        }
+
+        return elements;
     }
 
     // 13.2.5 Object Initializer, https://tc39.es/ecma262/#prod-ObjectLiteral


### PR DESCRIPTION
We now successfully parse and handle the data elements and elisions inside of an array literal.

Example Code:
```js
var a = [1,,];
a.length; // Returns 2
a[0]; // Returns 1
a[1]; // Returns undefined
a.hasOwnProperty(0); // Returns true
a.hasOwnProperty(1); // Returns false
```