### PR TITLE
JSS-79 Implement the Number constructor

### DIFF
--- a/JSS.Lib/Execution/Realm.cs
+++ b/JSS.Lib/Execution/Realm.cs
@@ -59,6 +59,8 @@ public sealed class Realm
 
         StringConstructor = new(FunctionPrototype);
 
+        NumberConstructor = new(FunctionPrototype);
+
         ArrayPrototype = new(ObjectPrototype);
         ArrayConstructor = new(FunctionPrototype);
 
@@ -234,6 +236,9 @@ public sealed class Realm
         // 20.1.1 The Object Constructor, https://tc39.es/ecma262/#sec-object-constructor
         globalProperties.Add("Object", new Property(ObjectConstructor, new(true, false, true)));
 
+        // 21.1.1 The Number Constructor, https://tc39.es/ecma262/#sec-number-constructor
+        globalProperties.Add("Number", new Property(NumberConstructor, new(true, false, true)));
+
         // 22.1.1 The String Constructor, https://tc39.es/ecma262/#sec-string-constructor
         globalProperties.Add("String", new Property(StringConstructor, new(true, false, true)));
 
@@ -328,6 +333,7 @@ public sealed class Realm
     internal ObjectConstructor ObjectConstructor { get; private set; }
     internal FunctionPrototype FunctionPrototype { get; private set; }
     internal StringConstructor StringConstructor { get; private set; }
+    internal NumberConstructor NumberConstructor { get; private set; }
     internal ArrayPrototype ArrayPrototype { get; private set; }
     internal ArrayConstructor ArrayConstructor { get; private set; }
     internal ErrorPrototype ErrorPrototype { get; private set; }

--- a/JSS.Lib/Runtime/Number.constructor.cs
+++ b/JSS.Lib/Runtime/Number.constructor.cs
@@ -3,6 +3,7 @@ using JSS.Lib.Execution;
 
 namespace JSS.Lib.Runtime;
 
+// 21.1.1 The Number Constructor, https://tc39.es/ecma262/#sec-number-constructor
 internal sealed class NumberConstructor : Object, ICallable, IConstructable
 {
     // The Number constructor has a [[Prototype]] internal slot whose value is %Function.prototype%.

--- a/JSS.Lib/Runtime/Number.constructor.cs
+++ b/JSS.Lib/Runtime/Number.constructor.cs
@@ -1,0 +1,49 @@
+﻿using JSS.Lib.AST.Values;
+using JSS.Lib.Execution;
+
+namespace JSS.Lib.Runtime;
+
+internal sealed class NumberConstructor : Object, ICallable, IConstructable
+{
+    // The Number constructor has a [[Prototype]] internal slot whose value is %Function.prototype%.
+    public NumberConstructor(FunctionPrototype prototype) : base(prototype)
+    {
+    }
+
+    public Completion Call(VM vm, Value thisArgument, List argumentList)
+    {
+        return Construct(vm, argumentList, Undefined.The);
+    }
+
+    public Completion Construct(VM vm, List argumentsList, Object newTarget)
+    {
+        // 1. If value is present, then
+        double n;
+        if (argumentsList.Count != 0)
+        {
+            // a. Let prim be ? ToNumeric(value).
+            var prim = argumentsList[0].ToNumeric(vm);
+            if (prim.IsAbruptCompletion()) return prim;
+
+            // FIXME: b. If prim is a BigInt, let n be 𝔽(ℝ(prim)).
+            // c. Otherwise, let n be prim.
+            n = prim.Value.AsNumber();
+        }
+        // 2. Else,
+        else
+        {
+            // a. Let n be +0𝔽.
+            n = 0;
+        }
+
+        // 3. If NewTarget is undefined, return n.
+        if (newTarget.IsUndefined()) return n;
+
+        // FIXME: 4. Let O be ? OrdinaryCreateFromConstructor(NewTarget, "%Number.prototype%", « [[NumberData]] »).
+        // 5. Set O.[[NumberData]] to n.
+        var O = new NumberObject(vm.ObjectPrototype, n);
+
+        // 6. Return O.
+        return O;
+    }
+}

--- a/JSS.Lib/Runtime/String.constructor.cs
+++ b/JSS.Lib/Runtime/String.constructor.cs
@@ -21,7 +21,7 @@ internal class StringConstructor : Object, ICallable, IConstructable
     {
         // 1. If value is not present, then
         string s;
-        if (argumentsList.Values.Count == 0)
+        if (argumentsList.Count == 0)
         {
             s = "";
         }

--- a/JSS.Lib/Runtime/String.constructor.cs
+++ b/JSS.Lib/Runtime/String.constructor.cs
@@ -3,6 +3,7 @@ using JSS.Lib.Execution;
 
 namespace JSS.Lib.Runtime;
 
+// 22.1.1 The String Constructor, https://tc39.es/ecma262/#sec-string-constructor
 internal class StringConstructor : Object, ICallable, IConstructable
 {
     // The String constructor has a [[Prototype]] internal slot whose value is %Function.prototype%.


### PR DESCRIPTION
We now implement the number constructor inside of JavaScript.

We can now call the Number constructor to perform type conversion to a number and construct from the Number constructor to create a number object.

Example Code:
```js
var obj = new Number("123"); // Returns a number object that holds the value 123 in the internal [[NumberData]] slot
var num = Number("123"); // Returns a number with the value of 123
```