### PR TITLE
JSS-80 Implement number constants on the Number constructor

### DIFF
--- a/JSS.Lib/Execution/Realm.cs
+++ b/JSS.Lib/Execution/Realm.cs
@@ -60,6 +60,7 @@ public sealed class Realm
         StringConstructor = new(FunctionPrototype);
 
         NumberConstructor = new(FunctionPrototype);
+        NumberConstructor.Initialize();
 
         ArrayPrototype = new(ObjectPrototype);
         ArrayConstructor = new(FunctionPrototype);

--- a/JSS.Lib/Runtime/Number.constructor.cs
+++ b/JSS.Lib/Runtime/Number.constructor.cs
@@ -11,11 +11,40 @@ internal sealed class NumberConstructor : Object, ICallable, IConstructable
     {
     }
 
+    public void Initialize()
+    {
+        // 21.1.2.1 Number.EPSILON, The value of Number.EPSILON is the Number value for the magnitude of the difference between 1 and the smallest value greater than 1 that is representable as a Number value.
+        DataProperties.Add("EPSILON", new(2.2204460492503130808472633361816E-16, new(false, false, false)));
+
+        // 21.1.2.6 Number.MAX_SAFE_INTEGER, The value of Number.MAX_SAFE_INTEGER is 9007199254740991𝔽 (𝔽(2**53 - 1)).
+        DataProperties.Add("MAX_SAFE_INTEGER", new(Math.Pow(2, 53) - 1, new(false, false, false)));
+
+        // 21.1.2.7 Number.MAX_VALUE, The value of Number.MAX_VALUE is the largest positive finite value of the Number type, which is approximately 1.7976931348623157 × 10**308.
+        DataProperties.Add("MAX_VALUE", new(double.MaxValue, new(false, false, false)));
+
+        // 21.1.2.8 Number.MIN_SAFE_INTEGER, The value of Number.MIN_SAFE_INTEGER is -9007199254740991𝔽 (𝔽(-(2**53 - 1))).
+        DataProperties.Add("MIN_SAFE_INTEGER", new(-(Math.Pow(2, 53) - 1), new(false, false, false)));
+
+        // 21.1.2.9 Number.MIN_VALUE, The value of Number.MIN_VALUE is the smallest positive value of the Number type, which is approximately 5 × 10 ** -324.
+        DataProperties.Add("MIN_VALUE", new(5E-324, new(false, false, false)));
+
+        // 21.1.2.10 Number.NaN, The value of Number.NaN is NaN.
+        DataProperties.Add("NaN", new(double.NaN, new(false, false, false)));
+
+        // 21.1.2.11 Number.NEGATIVE_INFINITY, The value of Number.NEGATIVE_INFINITY is -∞𝔽.
+        DataProperties.Add("NEGATIVE_INFINITY", new(double.NegativeInfinity, new(false, false, false)));
+
+        // 21.1.2.14 Number.POSITIVE_INFINITY, The value of Number.POSITIVE_INFINITY is +∞𝔽.
+        DataProperties.Add("POSITIVE_INFINITY", new(double.PositiveInfinity, new(false, false, false)));
+    }
+
+    // 21.1.1.1 Number ( value ), https://tc39.es/ecma262/#sec-number-constructor-number-value
     public Completion Call(VM vm, Value thisArgument, List argumentList)
     {
         return Construct(vm, argumentList, Undefined.The);
     }
 
+    // 21.1.1.1 Number ( value ), https://tc39.es/ecma262/#sec-number-constructor-number-value
     public Completion Construct(VM vm, List argumentsList, Object newTarget)
     {
         // 1. If value is present, then


### PR DESCRIPTION
We now implement the number constants that are defined on the Number constructor as defined by the spec.

```js
Number.NaN; // Returns NaN
Number.MAX_SAFE_INTEGER; // Returns 9007199254740991
Number.MAX_SAFE_INTEGER+1; // Returns 9007199254740992
Number.MAX_SAFE_INTEGER+2; // Returns 9007199254740992
```