### PR TITLE
JSS-81 implement the Boolean constructor

### DIFF
--- a/JSS.Lib/Execution/Realm.cs
+++ b/JSS.Lib/Execution/Realm.cs
@@ -57,6 +57,8 @@ public sealed class Realm
 
         FunctionPrototype.Initialize(vm);
 
+        BooleanConstructor = new(FunctionPrototype);
+
         StringConstructor = new(FunctionPrototype);
 
         NumberConstructor = new(FunctionPrototype);
@@ -237,6 +239,9 @@ public sealed class Realm
         // 20.1.1 The Object Constructor, https://tc39.es/ecma262/#sec-object-constructor
         globalProperties.Add("Object", new Property(ObjectConstructor, new(true, false, true)));
 
+        // 20.3.1 The Boolean Constructor, https://tc39.es/ecma262/#sec-boolean-constructor
+        globalProperties.Add("Boolean", new Property(BooleanConstructor, new(true, false, true)));
+
         // 21.1.1 The Number Constructor, https://tc39.es/ecma262/#sec-number-constructor
         globalProperties.Add("Number", new Property(NumberConstructor, new(true, false, true)));
 
@@ -333,6 +338,7 @@ public sealed class Realm
     internal ObjectPrototype ObjectPrototype { get; private set; }
     internal ObjectConstructor ObjectConstructor { get; private set; }
     internal FunctionPrototype FunctionPrototype { get; private set; }
+    internal BooleanConstructor BooleanConstructor { get; private set; }
     internal StringConstructor StringConstructor { get; private set; }
     internal NumberConstructor NumberConstructor { get; private set; }
     internal ArrayPrototype ArrayPrototype { get; private set; }

--- a/JSS.Lib/Runtime/Boolean.constructor.cs
+++ b/JSS.Lib/Runtime/Boolean.constructor.cs
@@ -1,0 +1,36 @@
+﻿using JSS.Lib.AST.Values;
+using JSS.Lib.Execution;
+
+namespace JSS.Lib.Runtime;
+
+// 20.3.1 The Boolean Constructor, https://tc39.es/ecma262/#sec-boolean-constructor
+internal sealed class BooleanConstructor : Object, ICallable, IConstructable
+{
+    // The Boolean constructor has a [[Prototype]] internal slot whose value is %Function.prototype%.
+    public BooleanConstructor(FunctionPrototype prototype) : base(prototype)
+    {
+    }
+
+    // 20.3.1.1 Boolean ( value ), https://tc39.es/ecma262/#sec-boolean-constructor-boolean-value
+    public Completion Call(VM vm, Value thisArgument, List argumentList)
+    {
+        return Construct(vm, argumentList, Undefined.The);
+    }
+
+    // 20.3.1.1 Boolean ( value ), https://tc39.es/ecma262/#sec-boolean-constructor-boolean-value
+    public Completion Construct(VM vm, List argumentsList, Object newTarget)
+    {
+        // 1. Let b be ToBoolean(value).
+        var b = argumentsList[0].ToBoolean();
+
+        // 2. If NewTarget is undefined, return b.
+        if (newTarget.IsUndefined()) return b;
+
+        // FIXME: 3. Let O be ? OrdinaryCreateFromConstructor(NewTarget, "%Boolean.prototype%", « [[BooleanData]] »).
+        // 4. Set O.[[BooleanData]] to b.
+        var O = new BooleanObject(vm.ObjectPrototype, b);
+
+        // 5. Return O.
+        return O;
+    }
+}


### PR DESCRIPTION
We now implement the Boolean constructor to be used in JavaScript.

When called, the boolean constructor performs type conversion to a boolean.

When used as a constructor, the boolean constructor creates a boolean object with the internal slot [[BooleanData]] holding the boolean value.

Example Code:
```js
var obj = new Boolean(1); // Returns a boolean object with the [[BooleanData]] internal slot holding true
var b = Boolean(1); // Returns a boolean value holding true
```