### PR TITLE
JSS-88 Implement parsing of the decimal part of numbers

### DIFF
--- a/JSS.Lib.UnitTests/ParserTests.cs
+++ b/JSS.Lib.UnitTests/ParserTests.cs
@@ -491,7 +491,14 @@ internal sealed class ParserTests
 
     static private readonly Dictionary<string, double> numericLiteralToValueTestCases = new()
     {
-        { "0", 0.0 }, { "1", 1.0 }, { "123", 123.0 }, { "1234567890", 1234567890.0 }
+        { "0", 0.0 },
+        { "0.0", 0.0 },
+        { "1", 1.0 },
+        { "1.0", 1.0 },
+        { "0.5", 0.5 },
+        { "1.5", 1.5 },
+        { "123", 123.0 },
+        { "1234567890", 1234567890.0 }
     };
 
     [TestCaseSource(nameof(numericLiteralToValueTestCases))]

--- a/JSS.Lib/Parser.cs
+++ b/JSS.Lib/Parser.cs
@@ -1,6 +1,7 @@
 ﻿using JSS.Lib.AST;
 using JSS.Lib.AST.Literal;
 using JSS.Lib.Execution;
+using System.Text;
 
 namespace JSS.Lib;
 
@@ -1478,11 +1479,34 @@ public sealed class Parser
 
     private NumericLiteral ParseNumericLiteral()
     {
-        var numericToken = _consumer.ConsumeTokenOfType(TokenType.Number);
+        StringBuilder numericLiteral = new();
+
+        var integerToken = _consumer.ConsumeTokenOfType(TokenType.Number);
+        numericLiteral.Append(integerToken.Data);
+
+        if (IsDecimalPart())
+        {
+            numericLiteral.Append(ParseDecimalPart());
+        }
+
         // FIXME: Proper error reporting
         // FIXME: Parse numbers according to the JS spec rather than the C# parse library
-        var numericValue = double.Parse(numericToken.Data);
+        var numericValue = double.Parse(numericLiteral.ToString());
         return new NumericLiteral(numericValue);
+    }
+
+    private bool IsDecimalPart()
+    {
+        return _consumer.IsTokenOfType(TokenType.Dot);
+    }
+
+    private string ParseDecimalPart()
+    {
+        _consumer.ConsumeTokenOfType(TokenType.Dot);
+        if (!IsNumericLiteral()) return ".0";
+
+        var decimalToken = _consumer.ConsumeTokenOfType(TokenType.Number);
+        return $".{decimalToken.Data}";
     }
 
     private bool IsStringLiteral()


### PR DESCRIPTION
We now parse numbers with decimals appropriately.

Example Code:
```js
0.1; // Returns 0.1
0.1 + 0.2; // Returns 0.30000000000000004
```