### PR TITLE
JSS-91 Limit call stack depth to 700 inside of JSS

### DIFF
--- a/JSS.Lib/Execution/VM.cs
+++ b/JSS.Lib/Execution/VM.cs
@@ -19,6 +19,11 @@ public sealed class VM
 
     internal void PushExecutionContext(ExecutionContext context)
     {
+        // FIXME: We currently have to rely on limiting our stack size as we would throw a stack overflow exception which is uncatchable.
+        // We should use a bytecode VM instead of an AST so that memory instead of stack size is the limiting factor
+        const int MAXIMUM_STACK_DEPTH = 700;
+        if (_executionContextStack.Count >= MAXIMUM_STACK_DEPTH) throw new InvalidOperationException($"Maximum stack depth ({MAXIMUM_STACK_DEPTH}) reached inside of JSS.");
+
         _executionContextStack.Push(context);
     }
 

--- a/JSS.Test262Runner/Test262Runner.cs
+++ b/JSS.Test262Runner/Test262Runner.cs
@@ -259,7 +259,7 @@ internal sealed class Test262Runner
             {
                 // NOTE: We throw the base Exception to signify that this would be a crash failure if executed.
                 // FIXME: Test cases using tcoHelper will check to prove TCO works, however, we have no TCO functionality and will cause the runner to crash with a stack overflow exception.
-                if (requiredHarnessFile == "tcoHelper.js") throw new Exception("tcoHelper.js was included, this test case will probably cause a stack overflow exception.");
+                //if (requiredHarnessFile == "tcoHelper.js") throw new Exception("tcoHelper.js was included, this test case will probably cause a stack overflow exception.");
 
                 var harnessScriptString = _harnessNameToContent[requiredHarnessFile];
                 var harnessScript = ParseAsGlobalCode(vm, harnessScriptString);


### PR DESCRIPTION
We currently will throw stack overflow exceptions when our call stack
grows too large as we use recursive decent and an AST walker for JSS.

The only way to prevent the uncatchable stack overflow exception is to
limit our call stack to throw a normal exception before we stack
overflow.