### PR TITLE
JSS-109 Define the string prototype on the string constructor

### DIFF
--- a/JSS.Lib/Execution/Realm.cs
+++ b/JSS.Lib/Execution/Realm.cs
@@ -67,6 +67,7 @@ public sealed class Realm
         StringConstructor = new(FunctionPrototype);
 
         StringPrototype.Initialize(this, vm);
+        StringConstructor.Initialize(this);
 
         NumberPrototype = new(ObjectPrototype);
         NumberConstructor = new(FunctionPrototype);

--- a/JSS.Lib/Runtime/String.constructor.cs
+++ b/JSS.Lib/Runtime/String.constructor.cs
@@ -11,6 +11,13 @@ internal class StringConstructor : Object, ICallable, IConstructable
     {
     }
 
+    public void Initialize(Realm realm)
+    {
+        // 22.1.2.3 String.prototype, https://tc39.es/ecma262/#sec-string.prototype
+        // This property has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }.
+        InternalDefineProperty("prototype", realm.StringPrototype, new(false, false, false));
+    }
+
     // 22.1.1.1 String ( value ), https://tc39.es/ecma262/#sec-string-constructor-string-value
     public Completion Call(VM vm, Value thisArgument, List argumentList)
     {


### PR DESCRIPTION
Example Code:
```js
String.prototype; // Returns the string prototype
```