### PR TITLE
JSS-115 Support cancellation while performing ScriptEvaluation

### DIFF
--- a/JSS.Lib/AST/AdditionExpression.cs
+++ b/JSS.Lib/AST/AdditionExpression.cs
@@ -14,6 +14,11 @@ internal sealed class AdditionExpression : IExpression
     // 13.8.1.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-addition-operator-plus-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Return ? EvaluateStringOrNumericBinaryExpression(AdditiveExpression, +, MultiplicativeExpression).
         return EvaluateStringOrNumericBinaryExpression(vm, Lhs, BinaryOpType.Add, Rhs);
     }

--- a/JSS.Lib/AST/ArrowFunctionExpression.cs
+++ b/JSS.Lib/AST/ArrowFunctionExpression.cs
@@ -39,6 +39,11 @@ internal sealed class ArrowFunctionExpression : IExpression
     // 15.3.5 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-arrow-function-definitions-runtime-semantics-evaluation
     public override Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Return InstantiateArrowFunctionExpression of ArrowFunction.
         return InstantiateArrowFunctionExpression(vm);
     }

--- a/JSS.Lib/AST/BasicAssignmentExpression.cs
+++ b/JSS.Lib/AST/BasicAssignmentExpression.cs
@@ -14,6 +14,11 @@ internal sealed class BasicAssignmentExpression : IExpression
     // 13.15.2 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-assignment-operators-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // FIXME: 1. If LeftHandSideExpression is neither an ObjectLiteral nor an ArrayLiteral, then
 
         // a. Let lref be ? Evaluation of LeftHandSideExpression.

--- a/JSS.Lib/AST/BinaryOpAssignmentExpression.cs
+++ b/JSS.Lib/AST/BinaryOpAssignmentExpression.cs
@@ -16,6 +16,11 @@ internal sealed class BinaryOpAssignmentExpression : IExpression
     // 13.15.2 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-assignment-operators-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let lref be ? Evaluation of LeftHandSideExpression.
         var lref = Lhs.Evaluate(vm);
         if (lref.IsAbruptCompletion()) return lref;

--- a/JSS.Lib/AST/BitwiseAndExpression.cs
+++ b/JSS.Lib/AST/BitwiseAndExpression.cs
@@ -14,6 +14,11 @@ internal sealed class BitwiseAndExpression : IExpression
     // 13.12.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-binary-bitwise-operators-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Return ? EvaluateStringOrNumericBinaryExpression(BitwiseANDExpression, &, EqualityExpression).
         return EvaluateStringOrNumericBinaryExpression(vm, Lhs, BinaryOpType.BitwiseAND, Rhs);
     }

--- a/JSS.Lib/AST/BitwiseNotExpression.cs
+++ b/JSS.Lib/AST/BitwiseNotExpression.cs
@@ -15,6 +15,11 @@ internal sealed class BitwiseNotExpression : IExpression
     // 13.5.6.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-bitwise-not-operator-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let expr be ? Evaluation of UnaryExpression.
         var expr = Expression.Evaluate(vm);
         if (expr.IsAbruptCompletion()) return expr;

--- a/JSS.Lib/AST/BitwiseOrExpression.cs
+++ b/JSS.Lib/AST/BitwiseOrExpression.cs
@@ -14,6 +14,11 @@ internal sealed class BitwiseOrExpression : IExpression
     // 13.12.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-binary-bitwise-operators-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Return ? EvaluateStringOrNumericBinaryExpression(BitwiseORExpression, |, BitwiseXORExpression).
         return EvaluateStringOrNumericBinaryExpression(vm, Lhs, BinaryOpType.BitwiseOR, Rhs);
     }

--- a/JSS.Lib/AST/BitwiseXorExpression.cs
+++ b/JSS.Lib/AST/BitwiseXorExpression.cs
@@ -14,6 +14,11 @@ internal sealed class BitwiseXorExpression : IExpression
     // 13.12.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-binary-bitwise-operators-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Return ? EvaluateStringOrNumericBinaryExpression(BitwiseXORExpression, ^, BitwiseANDExpression).
         return EvaluateStringOrNumericBinaryExpression(vm, Lhs, BinaryOpType.BitwiseXOR, Rhs);
     }

--- a/JSS.Lib/AST/Block.cs
+++ b/JSS.Lib/AST/Block.cs
@@ -13,6 +13,11 @@ internal sealed class Block : INode
     // 14.2.2 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-block-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let oldEnv be the running execution context's LexicalEnvironment.
         var currentExecutionContext = (vm.CurrentExecutionContext as ScriptExecutionContext)!;
         var oldEnv = currentExecutionContext.LexicalEnvironment;

--- a/JSS.Lib/AST/BreakStatement.cs
+++ b/JSS.Lib/AST/BreakStatement.cs
@@ -15,6 +15,11 @@ internal sealed class BreakStatement : INode
     // 14.9.2 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-break-statement-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let label be the StringValue of LabelIdentifier.
         var label = Label is not null ? Label.Name : "";
 

--- a/JSS.Lib/AST/CallExpression.cs
+++ b/JSS.Lib/AST/CallExpression.cs
@@ -16,6 +16,11 @@ internal sealed class CallExpression : IExpression
     // 13.3.6.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-function-calls-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let expr be the CallMemberExpression that is covered by CoverCallExpressionAndAsyncArrowHead.
         // 2. Let memberExpr be the MemberExpression of expr.
         // 3. Let arguments be the Arguments of expr.

--- a/JSS.Lib/AST/ComputedPropertyExpression.cs
+++ b/JSS.Lib/AST/ComputedPropertyExpression.cs
@@ -15,6 +15,11 @@ internal sealed class ComputedPropertyExpression : IExpression
     // 13.3.2.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-property-accessors-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let baseReference be ? Evaluation of MemberExpression.
         var baseReference = Lhs.Evaluate(vm);
         if (baseReference.IsAbruptCompletion()) return baseReference;

--- a/JSS.Lib/AST/ComputedPropertyName.cs
+++ b/JSS.Lib/AST/ComputedPropertyName.cs
@@ -13,6 +13,11 @@ internal sealed class ComputedPropertyName : INode
     // 13.2.5.4 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-object-initializer-runtime-semantics-evaluation
     public override Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let exprValue be ? Evaluation of AssignmentExpression.
         var exprValue = Expression.Evaluate(vm);
         if (exprValue.IsAbruptCompletion()) return exprValue;

--- a/JSS.Lib/AST/ConstDeclaration.cs
+++ b/JSS.Lib/AST/ConstDeclaration.cs
@@ -22,6 +22,11 @@ internal sealed class ConstDeclaration : Declaration
     // 14.3.1.2 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-let-and-const-declarations-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let bindingId be StringValue of BindingIdentifier.
         // 2. Let lhs be ! ResolveBinding(bindingId).
         var lhs = MUST(ScriptExecutionContext.ResolveBinding(vm, Identifier));

--- a/JSS.Lib/AST/ContinueStatement.cs
+++ b/JSS.Lib/AST/ContinueStatement.cs
@@ -14,6 +14,11 @@ internal sealed class ContinueStatement : INode
     // 14.8.2 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-continue-statement-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let label be the StringValue of LabelIdentifier.
         var label = Label is not null ? Label.Name : "";
 

--- a/JSS.Lib/AST/DebuggerStatement.cs
+++ b/JSS.Lib/AST/DebuggerStatement.cs
@@ -10,6 +10,11 @@ internal sealed class DebuggerStatement : INode
     // 14.16.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-debugger-statement-runtime-semantics-evaluation
     public override Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. If an implementation-defined debugging facility is available and enabled, then
         if (Debugger.IsAttached)
         {

--- a/JSS.Lib/AST/DeleteExpression.cs
+++ b/JSS.Lib/AST/DeleteExpression.cs
@@ -14,6 +14,11 @@ internal sealed class DeleteExpression : IExpression
     // 13.5.1.2 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-delete-operator-runtime-semantics-evaluation
     public override Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let ref be ? Evaluation of UnaryExpression.
         var uref = Expression.Evaluate(vm);
         if (uref.IsAbruptCompletion()) return uref;

--- a/JSS.Lib/AST/DivisionExpression.cs
+++ b/JSS.Lib/AST/DivisionExpression.cs
@@ -14,6 +14,11 @@ internal sealed class DivisionExpression : IExpression
     // 13.7.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-multiplicative-operators-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let opText be the source text matched by MultiplicativeOperator.
         // 2. Return ? EvaluateStringOrNumericBinaryExpression(MultiplicativeExpression, opText, ExponentiationExpression).
         return EvaluateStringOrNumericBinaryExpression(vm, Lhs, BinaryOpType.Divide, Rhs);

--- a/JSS.Lib/AST/EmptyStatement.cs
+++ b/JSS.Lib/AST/EmptyStatement.cs
@@ -9,6 +9,11 @@ internal sealed class EmptyStatement : INode
     // 14.4.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-empty-statement-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Return EMPTY.
         return Empty.The;
     }

--- a/JSS.Lib/AST/ExponentiationExpression.cs
+++ b/JSS.Lib/AST/ExponentiationExpression.cs
@@ -14,6 +14,11 @@ internal sealed class ExponentiationExpression : IExpression
     // 13.6.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-exp-operator-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Return ? EvaluateStringOrNumericBinaryExpression(UpdateExpression, **, ExponentiationExpression).
         return EvaluateStringOrNumericBinaryExpression(vm, Lhs, BinaryOpType.Exponentiate, Rhs);
     }

--- a/JSS.Lib/AST/ExpressionBody.cs
+++ b/JSS.Lib/AST/ExpressionBody.cs
@@ -13,6 +13,11 @@ internal sealed class ExpressionBody : INode
     // 15.3.5 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-arrow-function-definitions-runtime-semantics-evaluation
     public override Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let exprRef be ? Evaluation of AssignmentExpression.
         var exprRef = Expression.Evaluate(vm);
         if (exprRef.IsAbruptCompletion()) return exprRef;

--- a/JSS.Lib/AST/ExpressionStatement.cs
+++ b/JSS.Lib/AST/ExpressionStatement.cs
@@ -13,6 +13,11 @@ internal sealed class ExpressionStatement : INode
     // 14.5.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-expression-statement-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let exprRef be ? Evaluation of Expression.
         var exprRef = Expression.Evaluate(vm);
         if (exprRef.IsAbruptCompletion()) return exprRef;

--- a/JSS.Lib/AST/FunctionDeclaration.cs
+++ b/JSS.Lib/AST/FunctionDeclaration.cs
@@ -48,6 +48,11 @@ internal sealed class FunctionDeclaration : Declaration
     // 15.2.6 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-function-definitions-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Return EMPTY.
         return Empty.The;
     }

--- a/JSS.Lib/AST/FunctionExpression.cs
+++ b/JSS.Lib/AST/FunctionExpression.cs
@@ -18,6 +18,11 @@ internal sealed class FunctionExpression : IExpression
     // 15.2.6 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-function-definitions-runtime-semantics-evaluation
     public override Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Return InstantiateOrdinaryFunctionExpression of FunctionExpression.
         if (Identifier is null)
         {

--- a/JSS.Lib/AST/GreaterThanEqualsExpression.cs
+++ b/JSS.Lib/AST/GreaterThanEqualsExpression.cs
@@ -15,6 +15,11 @@ internal sealed class GreaterThanEqualsExpression : IExpression
     // 13.10.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let lref be ? Evaluation of RelationalExpression.
         var lref = Lhs.Evaluate(vm);
         if (lref.IsAbruptCompletion()) return lref;

--- a/JSS.Lib/AST/GreaterThanExpreesion.cs
+++ b/JSS.Lib/AST/GreaterThanExpreesion.cs
@@ -15,6 +15,11 @@ internal sealed class GreaterThanExpression : IExpression
     // 13.10.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let lref be ? Evaluation of RelationalExpression.
         var lref = Lhs.Evaluate(vm);
         if (lref.IsAbruptCompletion()) return lref;

--- a/JSS.Lib/AST/IIterationStatement.cs
+++ b/JSS.Lib/AST/IIterationStatement.cs
@@ -8,6 +8,11 @@ internal abstract class IIterationStatement : INode
     // 14.1.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-statement-semantics-runtime-semantics-evaluation
     public override Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let newLabelSet be a new empty List.
         // 2. Return ? LabelledEvaluation of this BreakableStatement with argument newLabelSet.
         return LabelledEvaluation(vm, new());

--- a/JSS.Lib/AST/Identifier.cs
+++ b/JSS.Lib/AST/Identifier.cs
@@ -29,6 +29,11 @@ internal sealed class Identifier : IExpression
     // 13.1.3 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-identifiers-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Return ? ResolveBinding(StringValue of Identifier).
         return ScriptExecutionContext.ResolveBinding(vm, Name);
     }

--- a/JSS.Lib/AST/IfStatement.cs
+++ b/JSS.Lib/AST/IfStatement.cs
@@ -48,6 +48,11 @@ internal sealed class IfStatement : INode
     // 14.6.2 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-if-statement-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         if (ElseCaseStatement is null)
         {
             return EvaluateWithoutElse(vm);

--- a/JSS.Lib/AST/InExpression.cs
+++ b/JSS.Lib/AST/InExpression.cs
@@ -14,6 +14,11 @@ internal sealed class InExpression : IExpression
     // 13.10.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let lref be ? Evaluation of RelationalExpression.
         var lref = Lhs.Evaluate(vm);
         if (lref.IsAbruptCompletion()) return lref;

--- a/JSS.Lib/AST/InstanceOfExpression.cs
+++ b/JSS.Lib/AST/InstanceOfExpression.cs
@@ -15,6 +15,11 @@ internal sealed class InstanceOfExpression : IExpression
     // 13.10.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation
     public override Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let lref be ? Evaluation of RelationalExpression.
         var lref = Lhs.Evaluate(vm);
         if (lref.IsAbruptCompletion()) return lref;

--- a/JSS.Lib/AST/LabelledStatement.cs
+++ b/JSS.Lib/AST/LabelledStatement.cs
@@ -16,6 +16,11 @@ internal sealed class LabelledStatement : INode
     // 14.13.3 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-labelled-statements-runtime-semantics-evaluation
     public override Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Return ? LabelledEvaluation of this LabelledStatement with argument « ».
         return LabelledEvaluation(vm, new());
     }

--- a/JSS.Lib/AST/LeftShiftExpression.cs
+++ b/JSS.Lib/AST/LeftShiftExpression.cs
@@ -14,6 +14,11 @@ internal sealed class LeftShiftExpression : IExpression
     // 13.9.1.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-left-shift-operator-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Return ? EvaluateStringOrNumericBinaryExpression(ShiftExpression, <<, AdditiveExpression).
         return EvaluateStringOrNumericBinaryExpression(vm, Lhs, BinaryOpType.LeftShift, Rhs);
     }

--- a/JSS.Lib/AST/LessThanEqualsExpression.cs
+++ b/JSS.Lib/AST/LessThanEqualsExpression.cs
@@ -15,6 +15,11 @@ internal sealed class LessThanEqualsExpression : IExpression
     // 13.10.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let lref be ? Evaluation of RelationalExpression.
         var lref = Lhs.Evaluate(vm);
         if (lref.IsAbruptCompletion()) return lref;

--- a/JSS.Lib/AST/LessThanExpression.cs
+++ b/JSS.Lib/AST/LessThanExpression.cs
@@ -15,6 +15,11 @@ internal sealed class LessThanExpression : IExpression
     // 13.10.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let lref be ? Evaluation of RelationalExpression.
         var lref = Lhs.Evaluate(vm);
         if (lref.IsAbruptCompletion()) return lref;

--- a/JSS.Lib/AST/LetDeclaration.cs
+++ b/JSS.Lib/AST/LetDeclaration.cs
@@ -22,6 +22,11 @@ internal sealed class LetDeclaration : Declaration
     // 14.3.1.2 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-let-and-const-declarations-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         if (Initializer is null)
         {
             return EvaluateWithoutInitializer(vm);

--- a/JSS.Lib/AST/LiteralPropertyName.cs
+++ b/JSS.Lib/AST/LiteralPropertyName.cs
@@ -15,6 +15,11 @@ internal sealed class LiteralPropertyName : INode
     // 13.2.5.4 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-object-initializer-runtime-semantics-evaluation
     public override Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         if (Literal is Identifier)
         {
             // 1. Return StringValue of IdentifierName.

--- a/JSS.Lib/AST/LogicalAndAssignmentExpression.cs
+++ b/JSS.Lib/AST/LogicalAndAssignmentExpression.cs
@@ -14,6 +14,11 @@ internal sealed class LogicalAndAssignmentExpression : IExpression
     // 13.15.2 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-assignment-operators-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let lref be ? Evaluation of LeftHandSideExpression.
         var lref = Lhs.Evaluate(vm);
         if (lref.IsAbruptCompletion()) return lref;

--- a/JSS.Lib/AST/LogicalAndExpression.cs
+++ b/JSS.Lib/AST/LogicalAndExpression.cs
@@ -14,6 +14,11 @@ internal sealed class LogicalAndExpression : IExpression
     // 13.13.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-binary-logical-operators-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let lref be ? Evaluation of LogicalANDExpression.
         var lref = Lhs.Evaluate(vm);
         if (lref.IsAbruptCompletion()) return lref;

--- a/JSS.Lib/AST/LogicalNotExpression.cs
+++ b/JSS.Lib/AST/LogicalNotExpression.cs
@@ -13,6 +13,11 @@ internal sealed class LogicalNotExpression : IExpression
     // 13.5.7.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-logical-not-operator-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let expr be ? Evaluation of UnaryExpression.
         var expr = Expression.Evaluate(vm);
         if (expr.IsAbruptCompletion()) return expr;

--- a/JSS.Lib/AST/LogicalOrAssignmentExpression.cs
+++ b/JSS.Lib/AST/LogicalOrAssignmentExpression.cs
@@ -14,6 +14,11 @@ internal sealed class LogicalOrAssignmentExpression : IExpression
     // 13.15.2 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-assignment-operators-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let lref be ? Evaluation of LeftHandSideExpression.
         var lref = Lhs.Evaluate(vm);
         if (lref.IsAbruptCompletion()) return lref;

--- a/JSS.Lib/AST/LogicalOrExpression.cs
+++ b/JSS.Lib/AST/LogicalOrExpression.cs
@@ -14,6 +14,11 @@ internal sealed class LogicalOrExpression : IExpression
     // 13.13.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-binary-logical-operators-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let lref be ? Evaluation of LogicalORExpression.
         var lref = Lhs.Evaluate(vm);
         if (lref.IsAbruptCompletion()) return lref;

--- a/JSS.Lib/AST/LooseEqualityExpression.cs
+++ b/JSS.Lib/AST/LooseEqualityExpression.cs
@@ -15,6 +15,11 @@ internal sealed class LooseEqualityExpression : IExpression
     // 13.11.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-equality-operators-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let lref be ? Evaluation of EqualityExpression.
         var lref = Lhs.Evaluate(vm);
         if (lref.IsAbruptCompletion()) return lref;

--- a/JSS.Lib/AST/LooseInequalityExpression.cs
+++ b/JSS.Lib/AST/LooseInequalityExpression.cs
@@ -15,6 +15,11 @@ internal sealed class LooseInequalityExpression : IExpression
     // 13.11.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-equality-operators-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let lref be ? Evaluation of EqualityExpression.
         var lref = Lhs.Evaluate(vm);
         if (lref.IsAbruptCompletion()) return lref;

--- a/JSS.Lib/AST/ModuloExpression.cs
+++ b/JSS.Lib/AST/ModuloExpression.cs
@@ -14,6 +14,11 @@ internal sealed class ModuloExpression : IExpression
     // 13.7.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-multiplicative-operators-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let opText be the source text matched by MultiplicativeOperator.
         // 2. Return ? EvaluateStringOrNumericBinaryExpression(MultiplicativeExpression, opText, ExponentiationExpression).
         return EvaluateStringOrNumericBinaryExpression(vm, Lhs, BinaryOpType.Remainder, Rhs);

--- a/JSS.Lib/AST/MultiplicationExpression.cs
+++ b/JSS.Lib/AST/MultiplicationExpression.cs
@@ -14,6 +14,11 @@ internal sealed class MultiplicationExpression : IExpression
     // 13.7.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-multiplicative-operators-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let opText be the source text matched by MultiplicativeOperator.
         // 2. Return ? EvaluateStringOrNumericBinaryExpression(MultiplicativeExpression, opText, ExponentiationExpression).
         return EvaluateStringOrNumericBinaryExpression(vm, Lhs, BinaryOpType.Multiply, Rhs);

--- a/JSS.Lib/AST/NewExpression.cs
+++ b/JSS.Lib/AST/NewExpression.cs
@@ -14,6 +14,11 @@ internal sealed class NewExpression : IExpression
     // 13.3.5.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-new-operator-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Return ? EvaluateNew(MemberExpression, Arguments).
         return EvaluateNew(vm);
     }

--- a/JSS.Lib/AST/NullCoalescingAssignmentExpression.cs
+++ b/JSS.Lib/AST/NullCoalescingAssignmentExpression.cs
@@ -14,6 +14,11 @@ internal sealed class NullCoalescingAssignmentExpression : IExpression
     // FIXME: 13.15.2 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-assignment-operators-runtime-semantics-evaluation
     public override Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let lref be ? Evaluation of LeftHandSideExpression.
         var lref = Lhs.Evaluate(vm);
         if (lref.IsAbruptCompletion()) return lref;

--- a/JSS.Lib/AST/PostfixDecrementExpression.cs
+++ b/JSS.Lib/AST/PostfixDecrementExpression.cs
@@ -15,6 +15,11 @@ internal sealed class PostfixDecrementExpression : IExpression
     // 13.4.3.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-postfix-decrement-operator-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let lhs be ? Evaluation of LeftHandSideExpression.
         var lhs = Expression.Evaluate(vm);
         if (lhs.IsAbruptCompletion()) return lhs;

--- a/JSS.Lib/AST/PostfixIncrementExpression.cs
+++ b/JSS.Lib/AST/PostfixIncrementExpression.cs
@@ -15,6 +15,11 @@ internal sealed class PostfixIncrementExpression : IExpression
     // 13.4.2.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-postfix-increment-operator-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let lhs be ? Evaluation of LeftHandSideExpression.
         var lhs = Expression.Evaluate(vm);
 

--- a/JSS.Lib/AST/PrefixDecrementExpression.cs
+++ b/JSS.Lib/AST/PrefixDecrementExpression.cs
@@ -15,6 +15,11 @@ internal sealed class PrefixDecrementExpression : IExpression
     // 13.4.5.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-prefix-decrement-operator-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let expr be ? Evaluation of UnaryExpression.
         var expr = Expression.Evaluate(vm);
         if (expr.IsAbruptCompletion()) return expr;

--- a/JSS.Lib/AST/PrefixIncrementExpression.cs
+++ b/JSS.Lib/AST/PrefixIncrementExpression.cs
@@ -15,6 +15,11 @@ internal sealed class PrefixIncrementExpression : IExpression
     // FIXME: 13.4.4.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-prefix-increment-operator-runtime-semantics-evaluation
     public override Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let expr be ? Evaluation of UnaryExpression.
         var expr = Expression.Evaluate(vm);
 

--- a/JSS.Lib/AST/PropertyExpression.cs
+++ b/JSS.Lib/AST/PropertyExpression.cs
@@ -15,6 +15,11 @@ internal sealed class PropertyExpression : IExpression
     // 13.3.2.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-property-accessors-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let baseReference be ? Evaluation of MemberExpression.
         var baseReference = Lhs.Evaluate(vm);
         if (baseReference.IsAbruptCompletion()) return baseReference;

--- a/JSS.Lib/AST/ReturnStatement.cs
+++ b/JSS.Lib/AST/ReturnStatement.cs
@@ -14,6 +14,11 @@ internal sealed class ReturnStatement : INode
     // 14.10.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-return-statement-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         if (ReturnExpression is null)
         {
             return EvaluateWithNoExpression();

--- a/JSS.Lib/AST/RightShiftExpression.cs
+++ b/JSS.Lib/AST/RightShiftExpression.cs
@@ -14,6 +14,11 @@ internal sealed class RightShiftExpression : IExpression
     // 13.9.2.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-signed-right-shift-operator-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Return ? EvaluateStringOrNumericBinaryExpression(ShiftExpression, >>, AdditiveExpression).
         return EvaluateStringOrNumericBinaryExpression(vm, Lhs, BinaryOpType.SignedRightShift, Rhs);
     }

--- a/JSS.Lib/AST/StatementList.cs
+++ b/JSS.Lib/AST/StatementList.cs
@@ -14,6 +14,11 @@ internal sealed class StatementList : INode
     // 14.2.2 Runtime Semantics: Evaluation, StatementList, https://tc39.es/ecma262/#sec-block-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let sl be ? Evaluation of StatementList.
         Completion completion = Empty.The;
         foreach (var statement in Statements)

--- a/JSS.Lib/AST/StrictEqualityExpression.cs
+++ b/JSS.Lib/AST/StrictEqualityExpression.cs
@@ -15,6 +15,11 @@ internal sealed class StrictEqualityExpression : IExpression
     // 13.11.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-equality-operators-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let lref be ? Evaluation of EqualityExpression.
         var lref = Lhs.Evaluate(vm);
         if (lref.IsAbruptCompletion()) return lref;

--- a/JSS.Lib/AST/StrictInequalityExpression.cs
+++ b/JSS.Lib/AST/StrictInequalityExpression.cs
@@ -15,6 +15,11 @@ internal sealed class StrictInequalityExpression : IExpression
     // 13.11.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-equality-operators-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let lref be ? Evaluation of EqualityExpression.
         var lref = Lhs.Evaluate(vm);
         if (lref.IsAbruptCompletion()) return lref;

--- a/JSS.Lib/AST/SubtractionExpression.cs
+++ b/JSS.Lib/AST/SubtractionExpression.cs
@@ -14,6 +14,11 @@ internal sealed class SubtractionExpression : IExpression
     // 13.8.2.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-subtraction-operator-minus-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Return ? EvaluateStringOrNumericBinaryExpression(AdditiveExpression, -, MultiplicativeExpression).
         return EvaluateStringOrNumericBinaryExpression(vm, Lhs, BinaryOpType.Subtract, Rhs);
     }

--- a/JSS.Lib/AST/SwitchStatement.cs
+++ b/JSS.Lib/AST/SwitchStatement.cs
@@ -442,6 +442,11 @@ internal sealed class SwitchStatement : INode
     // 14.13.4 Runtime Semantics: LabelledEvaluation, https://tc39.es/ecma262/#sec-runtime-semantics-labelledevaluation
     public override Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let stmtResult be Completion(Evaluation of SwitchStatement).
         var stmtResult = LabelledEvaluation(vm);
 

--- a/JSS.Lib/AST/TernaryExpression.cs
+++ b/JSS.Lib/AST/TernaryExpression.cs
@@ -15,6 +15,11 @@ internal sealed class TernaryExpression : IExpression
     // 13.14.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#prod-ConditionalExpression
     public override Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let lref be ? Evaluation of ShortCircuitExpression.
         var lref = TestExpression.Evaluate(vm);
         if (lref.IsAbruptCompletion()) return lref;

--- a/JSS.Lib/AST/ThisExpression.cs
+++ b/JSS.Lib/AST/ThisExpression.cs
@@ -8,6 +8,11 @@ internal sealed class ThisExpression : IExpression
     // 13.2.1.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-this-keyword-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Return ? ResolveThisBinding().
         return ScriptExecutionContext.ResolveThisBinding(vm);
     }

--- a/JSS.Lib/AST/ThrowStatement.cs
+++ b/JSS.Lib/AST/ThrowStatement.cs
@@ -13,6 +13,11 @@ internal sealed class ThrowStatement : INode
     // 14.14.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-throw-statement-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let exprRef be ? Evaluation of Expression.
         var exprRef = ThrowExpression.Evaluate(vm);
         if (exprRef.IsAbruptCompletion()) return exprRef;

--- a/JSS.Lib/AST/TryStatement.cs
+++ b/JSS.Lib/AST/TryStatement.cs
@@ -145,6 +145,11 @@ internal sealed class TryStatement : INode
     // 14.15.3 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-try-statement-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         if (CatchBlock is not null && FinallyBlock is not null)
         {
             return EvaluateWithCatchAndFinally(vm);

--- a/JSS.Lib/AST/TypeOfExpression.cs
+++ b/JSS.Lib/AST/TypeOfExpression.cs
@@ -15,6 +15,11 @@ internal sealed class TypeOfExpression : IExpression
     // 13.5.3.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-typeof-operator-runtime-semantics-evaluation
     public override Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let val be ? Evaluation of UnaryExpression.
         var val = Expression.Evaluate(vm);
         if (val.IsAbruptCompletion()) return val;

--- a/JSS.Lib/AST/UnaryMinusExpression.cs
+++ b/JSS.Lib/AST/UnaryMinusExpression.cs
@@ -15,6 +15,11 @@ internal sealed class UnaryMinusExpression : IExpression
     // 13.5.5.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-unary-minus-operator-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let expr be ? Evaluation of UnaryExpression.
         var expr = Expression.Evaluate(vm);
         if (expr.IsAbruptCompletion()) return expr;

--- a/JSS.Lib/AST/UnaryPlusExpression.cs
+++ b/JSS.Lib/AST/UnaryPlusExpression.cs
@@ -13,6 +13,11 @@ internal sealed class UnaryPlusExpression : IExpression
     // 13.5.4.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-unary-plus-operator-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let expr be ? Evaluation of UnaryExpression.
         var expr = Expression.Evaluate(vm);
         if (expr.IsAbruptCompletion()) return expr;

--- a/JSS.Lib/AST/UnsignedRightShiftExpression.cs
+++ b/JSS.Lib/AST/UnsignedRightShiftExpression.cs
@@ -14,6 +14,11 @@ internal sealed class UnsignedRightShiftExpression : IExpression
     // 13.9.2.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-signed-right-shift-operator-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Return ? EvaluateStringOrNumericBinaryExpression(ShiftExpression, >>>, AdditiveExpression).
         return EvaluateStringOrNumericBinaryExpression(vm, Lhs, BinaryOpType.UnsignedRightShift, Rhs);
     }

--- a/JSS.Lib/AST/VarDeclaration.cs
+++ b/JSS.Lib/AST/VarDeclaration.cs
@@ -29,6 +29,11 @@ internal sealed class VarDeclaration : INode
     // 14.3.2.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-variable-statement-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         if (Initializer is null)
         {
             return EvaluateWithoutInitializer();

--- a/JSS.Lib/AST/VarStatement.cs
+++ b/JSS.Lib/AST/VarStatement.cs
@@ -43,6 +43,11 @@ internal sealed class VarStatement : INode
     // 14.3.2.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-variable-statement-runtime-semantics-evaluation
     override public Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Perform ? Evaluation of VariableDeclarationList.
         foreach (var declaration in Declarations)
         {

--- a/JSS.Lib/AST/VoidExpression.cs
+++ b/JSS.Lib/AST/VoidExpression.cs
@@ -14,6 +14,11 @@ internal sealed class VoidExpression : IExpression
     // 13.5.2.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-void-operator-runtime-semantics-evaluation
     public override Completion Evaluate(VM vm)
     {
+        if (vm.CancellationToken.IsCancellationRequested)
+        {
+            return ThrowCancellationError(vm);
+        }
+
         // 1. Let expr be ? Evaluation of UnaryExpression.
         var expr = Expression.Evaluate(vm);
         if (expr.IsAbruptCompletion()) return expr;

--- a/JSS.Lib/Execution/Script.cs
+++ b/JSS.Lib/Execution/Script.cs
@@ -15,8 +15,10 @@ public sealed class Script
     }
 
     // 16.1.6 ScriptEvaluation ( scriptRecord ), https://tc39.es/ecma262/#sec-runtime-semantics-scriptevaluation
-    public Completion ScriptEvaluation()
+    public Completion ScriptEvaluation(CancellationToken cancellationToken = default)
     {
+        VM.CancellationToken = cancellationToken;
+
         // 1. Let globalEnv be scriptRecord.[[Realm]].[[GlobalEnv]].
         var globalEnv = Realm.GlobalEnv;
 

--- a/JSS.Lib/Execution/ThrowHelper.cs
+++ b/JSS.Lib/Execution/ThrowHelper.cs
@@ -90,6 +90,11 @@ internal static class ThrowHelper
         }
     }
 
+    static public Completion ThrowCancellationError(VM vm)
+    {
+        return ConstructError(vm, vm.EvalErrorConstructor, "a cancellation was requested while executing a script");
+    }
+
     static private Completion ConstructError(VM vm, NativeErrorConstructor constructor, string message)
     {
         List arguments = new();

--- a/JSS.Lib/Execution/VM.cs
+++ b/JSS.Lib/Execution/VM.cs
@@ -93,4 +93,6 @@ public sealed class VM
         }
     }
     private readonly Stack<bool> _strictStack = new();
+
+    internal CancellationToken CancellationToken { get; set; } = default;
 }


### PR DESCRIPTION
ScriptEvaluation now accepts a cancellation token. The cancellation token is stored inside of the VM.

Whenever a node is executed, it checks if a cancellation has been requested. If it has, then the node will return a throw completion eval error with an appropriate error message.